### PR TITLE
aggregation Logic for stg_facebook_ads

### DIFF
--- a/models/stg_facebook_ads.sql
+++ b/models/stg_facebook_ads.sql
@@ -26,20 +26,7 @@ with base as (
         sum(coalesce(impressions, 0)) as impressions,
         sum(coalesce(spend, 0)) as spend
     from base
-    group by 
-        cast(date_day as date),
-        base_url,
-        url_host,
-        url_path,
-        utm_source,
-        utm_medium,
-        utm_campaign,
-        utm_content,
-        utm_term,
-        cast(campaign_id as {{ dbt_utils.type_string() }}),
-        campaign_name,
-        cast(ad_set_id as {{ dbt_utils.type_string() }}),
-        ad_set_name
+    {{ dbt_utils.group_by(14) }}
 
 
 )

--- a/models/stg_facebook_ads.sql
+++ b/models/stg_facebook_ads.sql
@@ -22,10 +22,24 @@ with base as (
         cast(ad_set_id as {{ dbt_utils.type_string() }}) as ad_group_id,
         ad_set_name as ad_group_name,
         'Facebook Ads' as platform,
-        coalesce(clicks, 0) as clicks,
-        coalesce(impressions, 0) as impressions,
-        coalesce(spend, 0) as spend
+        sum(coalesce(clicks, 0)) as clicks,
+        sum(coalesce(impressions, 0)) as impressions,
+        sum(coalesce(spend, 0)) as spend
     from base
+    group by 
+        cast(date_day as date),
+        base_url,
+        url_host,
+        url_path,
+        utm_source,
+        utm_medium,
+        utm_campaign,
+        utm_content,
+        utm_term,
+        cast(campaign_id as {{ dbt_utils.type_string() }}),
+        campaign_name,
+        cast(ad_set_id as {{ dbt_utils.type_string() }}),
+        ad_set_name
 
 
 )


### PR DESCRIPTION
The grain of the source data of the stg_facebook_ads, facebook_ads__ad_adapter, produces records at the ad_id level, but the stg_facebook needs it at the ad_set_id level.  However, to avoid duplicates, the result set needs to be aggregated.