### PR TITLE
Add Google Ads selector to chose between final url and criteria reports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
             mkdir -p ~/.dbt
             cp integration_tests/ci/sample.profiles.yml ~/.dbt/profiles.yml
       - run:
-          name: "Run Tests - Spark"
+          name: "Run Tests - Spark (final_url)"
           command: |
             . venv/bin/activate
             echo `pwd`
@@ -33,7 +33,7 @@ jobs:
             dbt run --target spark --full-refresh
             dbt test --target spark
       - run:
-          name: "Run Tests - Redshift"
+          name: "Run Tests - Redshift (final_url)"
           command: |
             . venv/bin/activate
             echo `pwd`
@@ -43,7 +43,7 @@ jobs:
             dbt run --target redshift --full-refresh
             dbt test --target redshift
       - run:
-          name: "Run Tests - Snowflake"
+          name: "Run Tests - Snowflake (final_url)"
           command: |
             . venv/bin/activate
             echo `pwd`
@@ -53,7 +53,7 @@ jobs:
             dbt run --target snowflake --full-refresh
             dbt test --target snowflake
       - run:
-          name: "Run Tests - BigQuery"
+          name: "Run Tests - BigQuery (final_url)"
           environment:
               GCLOUD_SERVICE_KEY_PATH: "/home/circleci/gcloud-service-key.json"
 
@@ -64,4 +64,48 @@ jobs:
             dbt deps
             dbt seed --target bigquery --full-refresh
             dbt run --target bigquery --full-refresh
+            dbt test --target bigquery
+
+      - run:
+          name: "Run Tests - Spark (criteria)"
+          command: |
+            . venv/bin/activate
+            echo `pwd`
+            cd integration_tests
+            dbt deps
+            dbt seed --target spark --full-refresh
+            dbt run --target spark --full-refresh --vars 'ad_reporting__google_ads_type: criteria'
+            dbt test --target spark
+      - run:
+          name: "Run Tests - Redshift (criteria)"
+          command: |
+            . venv/bin/activate
+            echo `pwd`
+            cd integration_tests
+            dbt deps
+            dbt seed --target redshift --full-refresh
+            dbt run --target redshift --full-refresh --vars 'ad_reporting__google_ads_type: criteria'
+            dbt test --target redshift
+      - run:
+          name: "Run Tests - Snowflake (criteria)"
+          command: |
+            . venv/bin/activate
+            echo `pwd`
+            cd integration_tests
+            dbt deps
+            dbt seed --target snowflake --full-refresh
+            dbt run --target snowflake --full-refresh --vars 'ad_reporting__google_ads_type: criteria'
+            dbt test --target snowflake
+      - run:
+          name: "Run Tests - BigQuery (criteria)"
+          environment:
+              GCLOUD_SERVICE_KEY_PATH: "/home/circleci/gcloud-service-key.json"
+
+          command: |
+            . venv/bin/activate
+            echo `pwd`
+            cd integration_tests
+            dbt deps
+            dbt seed --target bigquery --full-refresh
+            dbt run --target bigquery --full-refresh --vars 'ad_reporting__google_ads_type: criteria'
             dbt test --target bigquery

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
             mkdir -p ~/.dbt
             cp integration_tests/ci/sample.profiles.yml ~/.dbt/profiles.yml
       - run:
-          name: "Run Tests - Spark (final_url)"
+          name: "Run Tests - Spark"
           command: |
             . venv/bin/activate
             echo `pwd`
@@ -31,9 +31,10 @@ jobs:
             dbt deps
             dbt seed --target spark --full-refresh
             dbt run --target spark --full-refresh
+            dbt run --target spark --full-refresh -m stg_google_ads+ --vars 'ad_reporting__google_ads_type: criteria'
             dbt test --target spark
       - run:
-          name: "Run Tests - Redshift (final_url)"
+          name: "Run Tests - Redshift"
           command: |
             . venv/bin/activate
             echo `pwd`
@@ -41,9 +42,10 @@ jobs:
             dbt deps
             dbt seed --target redshift --full-refresh
             dbt run --target redshift --full-refresh
+            dbt run --target redshift --full-refresh -m stg_google_ads+ --vars 'ad_reporting__google_ads_type: criteria'
             dbt test --target redshift
       - run:
-          name: "Run Tests - Snowflake (final_url)"
+          name: "Run Tests - Snowflake"
           command: |
             . venv/bin/activate
             echo `pwd`
@@ -51,9 +53,10 @@ jobs:
             dbt deps
             dbt seed --target snowflake --full-refresh
             dbt run --target snowflake --full-refresh
+            dbt run --target snowflake --full-refresh -m stg_google_ads+ --vars 'ad_reporting__google_ads_type: criteria'
             dbt test --target snowflake
       - run:
-          name: "Run Tests - BigQuery (final_url)"
+          name: "Run Tests - BigQuery"
           environment:
               GCLOUD_SERVICE_KEY_PATH: "/home/circleci/gcloud-service-key.json"
 
@@ -64,48 +67,5 @@ jobs:
             dbt deps
             dbt seed --target bigquery --full-refresh
             dbt run --target bigquery --full-refresh
-            dbt test --target bigquery
-
-      - run:
-          name: "Run Tests - Spark (criteria)"
-          command: |
-            . venv/bin/activate
-            echo `pwd`
-            cd integration_tests
-            dbt deps
-            dbt seed --target spark --full-refresh
-            dbt run --target spark --full-refresh --vars 'ad_reporting__google_ads_type: criteria' -m stg_google_ads+
-            dbt test --target spark
-      - run:
-          name: "Run Tests - Redshift (criteria)"
-          command: |
-            . venv/bin/activate
-            echo `pwd`
-            cd integration_tests
-            dbt deps
-            dbt seed --target redshift --full-refresh
-            dbt run --target redshift --full-refresh --vars 'ad_reporting__google_ads_type: criteria' -m stg_google_ads+
-            dbt test --target redshift
-      - run:
-          name: "Run Tests - Snowflake (criteria)"
-          command: |
-            . venv/bin/activate
-            echo `pwd`
-            cd integration_tests
-            dbt deps
-            dbt seed --target snowflake --full-refresh
-            dbt run --target snowflake --full-refresh --vars 'ad_reporting__google_ads_type: criteria' -m stg_google_ads+
-            dbt test --target snowflake
-      - run:
-          name: "Run Tests - BigQuery (criteria)"
-          environment:
-              GCLOUD_SERVICE_KEY_PATH: "/home/circleci/gcloud-service-key.json"
-
-          command: |
-            . venv/bin/activate
-            echo `pwd`
-            cd integration_tests
-            dbt deps
-            dbt seed --target bigquery --full-refresh
-            dbt run --target bigquery --full-refresh --vars 'ad_reporting__google_ads_type: criteria' -m stg_google_ads+
+            dbt run --target bigquery --full-refresh -m stg_google_ads+ --vars 'ad_reporting__google_ads_type: criteria'
             dbt test --target bigquery

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
             cd integration_tests
             dbt deps
             dbt seed --target spark --full-refresh
-            dbt run --target spark --full-refresh --vars 'ad_reporting__google_ads_type: criteria'
+            dbt run --target spark --full-refresh --vars 'ad_reporting__google_ads_type: criteria' -m stg_google_ads+
             dbt test --target spark
       - run:
           name: "Run Tests - Redshift (criteria)"
@@ -84,7 +84,7 @@ jobs:
             cd integration_tests
             dbt deps
             dbt seed --target redshift --full-refresh
-            dbt run --target redshift --full-refresh --vars 'ad_reporting__google_ads_type: criteria'
+            dbt run --target redshift --full-refresh --vars 'ad_reporting__google_ads_type: criteria' -m stg_google_ads+
             dbt test --target redshift
       - run:
           name: "Run Tests - Snowflake (criteria)"
@@ -94,7 +94,7 @@ jobs:
             cd integration_tests
             dbt deps
             dbt seed --target snowflake --full-refresh
-            dbt run --target snowflake --full-refresh --vars 'ad_reporting__google_ads_type: criteria'
+            dbt run --target snowflake --full-refresh --vars 'ad_reporting__google_ads_type: criteria' -m stg_google_ads+
             dbt test --target snowflake
       - run:
           name: "Run Tests - BigQuery (criteria)"
@@ -107,5 +107,5 @@ jobs:
             cd integration_tests
             dbt deps
             dbt seed --target bigquery --full-refresh
-            dbt run --target bigquery --full-refresh --vars 'ad_reporting__google_ads_type: criteria'
+            dbt run --target bigquery --full-refresh --vars 'ad_reporting__google_ads_type: criteria' -m stg_google_ads+
             dbt test --target bigquery

--- a/README.md
+++ b/README.md
@@ -174,6 +174,20 @@ models:
 
 ```
 
+### Google Ads adapter type selection
+
+The Google Ads packages has two 'ad adapter' tables. One is based on the Final URL report and the other is based on the Criteria report. 
+
+If you have specifically chosen to sync one or the other of these tables, you can tell dbt which to use. It will use the Final URL report by default.
+
+```yml
+# dbt_project.yml
+
+...
+vars:
+  ad_reporting__google_ads_type: 'criteria' # or 'final_url'
+```
+
 ## Database Support
 
 This package has been tested on BigQuery, Snowflake, Redshift, Postgres, and Spark.

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -14,6 +14,7 @@ vars:
   ad_reporting__snapchat_ads_enabled: true
   dbt_utils_dispatch_list: ['spark_utils', 'fivetran_utils']
   fivetran_utils_dispatch_list: ['spark_utils']
+  ad_reporting__google_ads_type: 'final_url'
 
 models:
   ad_reporting:

--- a/models/stg_google_ads.sql
+++ b/models/stg_google_ads.sql
@@ -3,7 +3,11 @@
 with base as (
 
     select *
+    {% if var('ad_reporting__google_ads_type') == 'final_url' %}
     from {{ ref('google_ads__url_ad_adapter')}}
+    {% elif var('ad_reporting__google_ads_type') == 'criteria' %}
+    from {{ ref('google_ads__criteria_ad_adapter')}}
+    {% endif %}
 
 ), fields as (
 
@@ -16,6 +20,7 @@ with base as (
         cast(campaign_id as {{ dbt_utils.type_string() }}) as campaign_id,
         ad_group_name,
         cast(ad_group_id as {{ dbt_utils.type_string() }}) as ad_group_id,
+        {% if var('ad_reporting__google_ads_type') == 'final_url' %}
         base_url,
         url_host,
         url_path,
@@ -27,7 +32,16 @@ with base as (
         coalesce(clicks, 0) as clicks,
         coalesce(impressions, 0) as impressions,
         coalesce(spend, 0) as spend
+        {% elif var('ad_reporting__google_ads_type') == 'criteria' %}
+        sum(coalesce(clicks, 0)) as clicks,
+        sum(coalesce(impressions, 0)) as impressions,
+        sum(coalesce(spend, 0)) as spend
+        {% endif %}
+
     from base
+    {% if var('ad_reporting__google_ads_type') == 'criteria' %}
+    group by 1,2,3,4,5,6,7,8
+    {% endif %}
 
 )
 


### PR DESCRIPTION
**Are you a current Fivetran customer?** 
Let's say yes.

**What change(s) does this PR introduce?** 
<!--- Describe what changes your PR introduces to the package -->
This PR gives users the option to select whether they would like to use the `url_ad_adapter` or the `criteria_ad_adapter` from Google Ads as part of this package.

**Does this PR introduce a breaking change?**
<!--- Does this PR introduce changes that -->
<!--- Mark yes or no (eg. [x] Yes). If yes, link the issue. -->
- [ ] Yes (please provide breaking change details below.)
- [x] No  (please provide explanation how the change is non breaking below.)

The package used the final URL report before, which continues to be the default.

**Is this PR in response to a previously created Issue**
<!--- If an Issue was created it is helpful to track the progress by linking it in the PR. -->
<!--- Mark yes or no (eg. [x] Yes). If yes, link the issue. -->
- [x] Yes, closes [this issue](https://github.com/fivetran/dbt_ad_reporting/issues/16)
- [ ] No 

**How did you test the PR changes?** 
<!--- Proof of testing is required in order for the PR to be approved. -->
<!--- To check a box, remove the space and insert an x in the box (eg. [x] CircleCi). --> 
- [x] CircleCi <!--- CircleCi testing is only applicable to Fivetran employees. --> 
- [ ] Other (please provide additional testing details below)

**Provide an emoji that best describes your current mood**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
:dancer:

**TODO**:
This PR shouldn't be moved until:
1. We decide on a strategy for [this issue](https://github.com/fivetran/dbt_google_ads/issues/7)
2. We decide on whether this is the right CircleCI strategy. (We are now running all tests twice, once for final url and another time for criteria)