### PR TITLE
Bugfix/budget association

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@
 - `dbt_utils.surrogate_key` has also been updated to `dbt_utils.generate_surrogate_key`. Since the method for creating surrogate keys differ, we suggest all users do a `full-refresh` for the most accurate data. For more information, please refer to dbt-utils [release notes](https://github.com/dbt-labs/dbt-utils/releases) for this update.
 - Dependencies on `fivetran/fivetran_utils` have been upgraded, previously `[">=0.3.0", "<0.4.0"]` now `[">=0.4.0", "<0.5.0"]`.
 
-[PR #](link) includes the following updates:
+[PR #68](https://github.com/fivetran/dbt_ad_reporting/pull/68) includes the following updates:
 - Added `budget_association_status` into the `stg_microsoft_ads__campaign_daily_report` table in order to account for campaign budgets that end midday. Including `budget_association_status` as another grain to test by, will reduce tests failing due to non-uniqueness of rows. This change will therefore yield an update this package's `integration_tests/seeds/microsoft_ads_campaign_performance_daily_report_data`. 
 
 # dbt_ad_reporting v1.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@
 - Dependencies on `fivetran/fivetran_utils` have been upgraded, previously `[">=0.3.0", "<0.4.0"]` now `[">=0.4.0", "<0.5.0"]`.
 
 [PR #68](https://github.com/fivetran/dbt_ad_reporting/pull/68) includes the following updates:
-- Added `budget_association_status` into the `stg_microsoft_ads__campaign_daily_report` table in order to account for campaign budgets that end midday. Including `budget_association_status` as another grain to test by, will reduce tests failing due to non-uniqueness of rows. This change will therefore yield an update this package's `integration_tests/seeds/microsoft_ads_campaign_performance_daily_report_data`. 
+- Updated this package's `integration_tests/seeds/microsoft_ads_campaign_performance_daily_report_data` in light of [PR #23](https://github.com/fivetran/dbt_microsoft_ads_source/pull/23) on `dbt_microsoft_ads_source`.
 
 # dbt_ad_reporting v1.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@
 - `dbt_utils.surrogate_key` has also been updated to `dbt_utils.generate_surrogate_key`. Since the method for creating surrogate keys differ, we suggest all users do a `full-refresh` for the most accurate data. For more information, please refer to dbt-utils [release notes](https://github.com/dbt-labs/dbt-utils/releases) for this update.
 - Dependencies on `fivetran/fivetran_utils` have been upgraded, previously `[">=0.3.0", "<0.4.0"]` now `[">=0.4.0", "<0.5.0"]`.
 
+[PR #](link) includes the following updates:
+- Added `budget_association_status` into the `stg_microsoft_ads__campaign_daily_report` table in order to account for campaign budgets that end midday. Including `budget_association_status` as another grain to test by, will reduce tests failing due to non-uniqueness of rows. This change will therefore yield an update this package's `integration_tests/seeds/microsoft_ads_campaign_performance_daily_report_data`. 
+
 # dbt_ad_reporting v1.0.1
 
 ## 🎉 Feature Enhancements 🎉 

--- a/integration_tests/seeds/microsoft_ads_campaign_performance_daily_report_data.csv
+++ b/integration_tests/seeds/microsoft_ads_campaign_performance_daily_report_data.csv
@@ -1,2631 +1,2631 @@
-date,account_id,campaign_id,currency_code,device_os,device_type,network,ad_distribution,bid_match_type,delivered_match_type,top_vs_other,clicks,impressions,spend
-2019-05-22,150175881,359751135,USD,Unknown,Unknown,Bing and Yahoo! search,Search,Unknown,Unknown,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-30,150175881,359751135,USD,Unknown,Unknown,Bing and Yahoo! search,Search,Unknown,Unknown,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-23,150175881,359751135,USD,Unknown,Unknown,Bing and Yahoo! search,Search,Unknown,Unknown,Bing and Yahoo! search - Top,0,0,0.0
-2019-06-27,150175881,359751135,USD,Unknown,Unknown,Bing and Yahoo! search,Search,Unknown,Unknown,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-15,150175881,359751135,USD,Unknown,Unknown,Bing and Yahoo! search,Search,Unknown,Unknown,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-09,150175881,359751135,USD,Unknown,Unknown,Bing and Yahoo! search,Search,Unknown,Unknown,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-02,150175881,359751135,USD,Unknown,Unknown,Bing and Yahoo! search,Search,Unknown,Unknown,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-20,150175881,359751135,USD,Unknown,Unknown,Bing and Yahoo! search,Search,Unknown,Unknown,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-26,150175881,359751135,USD,Unknown,Unknown,Bing and Yahoo! search,Search,Unknown,Unknown,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-22,150175881,359751135,USD,Unknown,Unknown,Bing and Yahoo! search,Search,Unknown,Unknown,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-25,150175881,359751135,USD,Unknown,Unknown,Bing and Yahoo! search,Search,Unknown,Unknown,Bing and Yahoo! search - Top,0,0,0.0
-2019-06-26,150175881,359751135,USD,Unknown,Unknown,Bing and Yahoo! search,Search,Unknown,Unknown,Bing and Yahoo! search - Top,0,0,0.0
-2019-06-10,150175881,359751135,USD,Unknown,Unknown,Bing and Yahoo! search,Search,Unknown,Unknown,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-15,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,0,0.0
-2019-04-23,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-06,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-08,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,0,0.0
-2019-05-18,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2019-05-18,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-28,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-01-23,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2019-05-27,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,0,0.0
-2019-05-05,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-27,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,0,0.0
-2019-05-16,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2019-04-28,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,0,0.0
-2019-04-21,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-15,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-20,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,0,0.0
-2019-04-14,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-14,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,0,0.0
-2019-04-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-01-23,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-25,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-12,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,0,0.0
-2019-05-10,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-20,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,0,0.0
-2019-04-23,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-28,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-06,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-03,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,0,0.0
-2019-04-07,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,0,0.0
-2019-04-17,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,0,0.0
-2019-05-21,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-27,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-05-25,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-02,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,0,0.0
-2019-04-25,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-03,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,0,0.0
-2019-05-20,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-05-21,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-25,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-04-07,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-24,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-15,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-10,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-11,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,0,0.0
-2019-04-29,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-19,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,0,0.0
-2019-04-28,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-27,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-13,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,0,0.0
-2019-04-30,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-30,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-12,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,0,0.0
-2019-05-20,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,0,0.0
-2019-04-29,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2019-05-18,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,0,0.0
-2019-05-28,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,0,0.0
-2019-04-11,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,0,0.0
-2019-05-26,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-22,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-24,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-06,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-20,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-24,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-08,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-05-02,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,0,0.0
-2019-05-11,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,0,0.0
-2019-05-02,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-19,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-09,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2019-04-12,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-29,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-19,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,0,0.0
-2019-04-16,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,0,0.0
-2019-05-15,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-04-21,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-05,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-12,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,0,0.0
-2019-05-25,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,0,0.0
-2019-04-20,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-26,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-15,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2019-05-14,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2019-05-14,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-04-26,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,0,0.0
-2019-05-12,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-19,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-25,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-22,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,0,0.0
-2019-04-19,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,0,0.0
-2019-04-24,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-08,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2019-05-18,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-12,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-16,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,0,0.0
-2019-04-28,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,0,0.0
-2019-04-27,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2019-04-17,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,0,0.0
-2019-05-22,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-24,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,0,0.0
-2019-05-27,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,0,0.0
-2019-05-02,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,0,0.0
-2019-05-11,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-17,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-07,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,0,0.0
-2019-04-13,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-10,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-24,150175881,359751135,USD,Android,Tablet,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-07,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,0,0.0
-2019-05-27,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-29,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-05-16,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-16,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-27,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-10,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-05-03,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-23,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-24,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2019-04-27,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-21,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-22,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-27,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-05,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-03,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-05-02,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-25,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,0,0.0
-2019-05-27,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,0,0.0
-2019-05-17,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-21,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,0,0.0
-2018-11-28,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-29,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-28,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-25,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-11,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2018-12-13,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-08,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,0,0.0
-2019-05-19,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,0,0.0
-2019-05-28,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-05-04,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,0,0.0
-2019-04-13,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,0,0.0
-2019-04-19,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-20,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-09,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,0,0.0
-2019-04-07,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-26,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-05,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-08,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-24,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-25,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,0,0.0
-2019-04-06,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-19,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-09,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,0,0.0
-2019-05-02,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,0,0.0
-2019-04-30,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-10,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,0,0.0
-2019-04-26,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,0,0.0
-2019-04-20,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-04,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,0,0.0
-2019-05-08,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-19,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-10,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2019-05-28,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-24,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-05,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,0,0.0
-2019-05-08,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,0,0.0
-2019-05-03,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,0,0.0
-2019-05-11,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-18,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,0,0.0
-2019-04-12,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,0,0.0
-2019-04-08,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,0,0.0
-2019-04-11,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,0,0.0
-2019-05-04,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,0,0.0
-2019-04-10,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-22,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-17,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-13,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,0,0.0
-2019-04-18,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,0,0.0
-2019-05-11,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,0,0.0
-2019-05-13,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-16,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-05,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,0,0.0
-2019-05-19,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-13,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,0,0.0
-2019-04-07,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-20,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-21,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,0,0.0
-2019-04-12,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-26,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,0,0.0
-2019-05-09,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-01,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-21,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-01-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-06,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-01,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-04,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,2,0.0
-2019-05-05,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,4,0.0
-2019-05-15,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-20,150175881,359751135,USD,iOS,Tablet,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,2,0.0
-2019-05-19,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-08,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,2,0.0
-2019-04-23,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-08,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,2,0.0
-2019-04-18,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,3,0.0
-2019-04-19,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-18,150175881,359751135,USD,Android,Tablet,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2019-04-09,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,3,0.0
-2019-04-21,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-02-19,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-02-20,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2019-05-20,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-05,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-01,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,2,0.0
-2019-05-17,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-22,150175881,359751135,USD,iOS,Tablet,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2019-04-23,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,2,0.0
-2019-04-19,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-07,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-22,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-01-23,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-07,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,16,0.0
-2019-04-30,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-21,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,4,0.0
-2019-04-26,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Other,0,2,0.0
-2019-05-20,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Other,0,2,0.0
-2019-05-07,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,4,0.0
-2019-05-08,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-04-27,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-17,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,2,0.0
-2019-04-09,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,2,0.0
-2019-05-24,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,3,0.0
-2019-05-26,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,4,0.0
-2019-03-26,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2019-05-01,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-04-29,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2019-05-12,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,1,0.0
-2019-05-21,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,2,0.0
-2019-05-04,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-13,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-23,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-04-20,150175881,359751135,USD,iOS,Tablet,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Other,0,3,0.0
-2019-04-15,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,15,0.0
-2019-04-20,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,3,0.0
-2019-04-24,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-05,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-30,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,7,0.0
-2019-05-06,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,2,0.0
-2019-04-30,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,3,0.0
-2019-05-14,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,5,0.0
-2019-04-25,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,2,0.0
-2019-05-24,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,3,0.0
-2019-04-12,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-20,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,5,0.0
-2019-04-25,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,5,0.0
-2019-03-04,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2019-05-15,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,3,0.0
-2019-05-28,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,2,0.0
-2019-05-17,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Other,0,1,0.0
-2019-04-11,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,4,0.0
-2019-04-15,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,0,1,0.0
-2019-04-21,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,2,0.0
-2018-10-24,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2019-05-07,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-14,150175881,359751135,USD,Android,Tablet,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2019-05-12,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-04,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,3,0.0
-2019-05-17,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,3,0.0
-2019-05-05,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,16,0.0
-2019-04-17,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-18,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,3,0.0
-2019-04-23,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,25,0.0
-2019-04-24,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,23,0.0
-2019-03-12,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-04,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-03,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,2,0.0
-2019-05-03,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,6,0.0
-2019-05-02,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-14,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,2,0.0
-2019-04-26,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-26,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,2,0.0
-2019-04-15,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2019-05-23,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,1,0.0
-2019-04-21,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2019-04-10,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,13,0.0
-2018-10-23,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-08,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-01,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-14,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,4,0.0
-2019-05-21,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-21,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,4,0.0
-2019-05-05,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,4,0.0
-2019-05-28,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,11,0.0
-2019-04-23,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,2,0.0
-2019-04-15,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,4,0.0
-2019-05-21,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-01-22,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2019-04-30,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-28,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,2,0.0
-2019-05-04,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-02,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,5,0.0
-2019-04-30,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,3,0.0
-2019-04-30,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-08,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,0,1,0.0
-2019-04-23,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-04-12,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Other,0,1,0.0
-2019-04-16,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,4,0.0
-2019-05-26,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-22,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,4,0.0
-2019-05-22,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,4,0.0
-2019-04-29,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Other,0,1,0.0
-2019-03-22,150175881,349886458,USD,iOS,Tablet,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-27,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2019-04-30,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Other,0,1,0.0
-2019-05-04,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Other,0,3,0.0
-2019-05-10,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,3,0.0
-2019-04-29,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,3,0.0
-2019-05-20,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,2,0.0
-2019-04-29,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-04-27,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-01,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,17,0.0
-2019-04-11,150175881,359751135,USD,iOS,Tablet,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,5,0.0
-2019-04-17,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,4,0.0
-2019-04-22,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2018-12-05,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,1,0.0
-2019-05-19,150175881,359751135,USD,Android,Tablet,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,1,0.0
-2019-05-08,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,4,0.0
-2019-05-15,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-05,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2019-04-30,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,2,0.0
-2019-05-04,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,5,0.0
-2019-04-09,150175881,359751135,USD,iOS,Tablet,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2019-04-23,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,4,0.0
-2019-05-22,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,6,0.0
-2019-04-10,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,1,0.0
-2019-01-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,0,3,0.0
-2019-05-09,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-10,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,4,0.0
-2019-05-27,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,10,0.0
-2019-05-01,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,2,0.0
-2019-05-17,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-05-22,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-04-18,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,0,1,0.0
-2019-04-07,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,6,0.0
-2019-04-15,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,3,0.0
-2019-05-26,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2018-10-19,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-03-08,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-02-25,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,2,0.0
-2019-05-15,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,2,0.0
-2019-05-13,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,11,0.0
-2019-05-17,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-18,150175881,359751135,USD,iOS,Tablet,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-08,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Other,0,1,0.0
-2019-05-13,150175881,359751135,USD,iOS,Tablet,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-15,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,4,0.0
-2019-05-11,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,7,0.0
-2019-04-24,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-16,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,4,0.0
-2019-04-22,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,2,0.0
-2019-04-05,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Other,0,1,0.0
-2019-05-28,150175881,359751135,USD,Windows,Computer,Audience,Audience,Broad,Broad,Audience network,0,1,0.0
-2019-05-18,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-19,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,11,0.0
-2019-04-23,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-04-09,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,2,0.0
-2019-05-24,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-04-09,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,13,0.0
-2019-04-08,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,1,0.0
-2018-11-12,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,1,0.0
-2019-03-06,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2019-04-06,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,1,0.0
-2018-12-05,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-16,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-17,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Other,0,1,0.0
-2019-05-10,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-08,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,3,0.0
-2019-05-08,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-27,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Other,0,2,0.0
-2019-05-21,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,3,0.0
-2019-04-26,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,3,0.0
-2019-04-08,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-04-12,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,4,0.0
-2019-04-10,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,7,0.0
-2019-05-26,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,5,0.0
-2019-04-25,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-04-17,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-04-15,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,4,0.0
-2019-04-22,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,11,0.0
-2019-05-27,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,3,0.0
-2019-05-25,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-26,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,3,0.0
-2019-05-05,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,2,0.0
-2019-05-28,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,3,0.0
-2019-04-25,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-08,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,12,0.0
-2019-05-17,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-04-29,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,8,0.0
-2019-05-14,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2019-05-15,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,2,0.0
-2019-05-14,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,5,0.0
-2019-04-07,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,3,0.0
-2019-04-09,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,2,0.0
-2019-04-18,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2019-02-06,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-02,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,3,0.0
-2019-05-13,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-11,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-15,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-01,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,2,0.0
-2019-05-08,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,2,0.0
-2019-05-17,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-16,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,19,0.0
-2019-04-15,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-04-10,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,2,0.0
-2019-04-17,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-04-16,150175881,359751135,USD,Android,Tablet,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,2,0.0
-2019-05-22,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,6,0.0
-2019-04-17,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,6,0.0
-2019-05-17,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,2,0.0
-2019-05-17,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-14,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-17,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,0,2,0.0
-2019-05-01,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,6,0.0
-2019-04-09,150175881,359751135,USD,Android,Tablet,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-24,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,4,0.0
-2019-04-23,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,0,2,0.0
-2019-04-27,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-25,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-08,150175881,359751135,USD,Windows,Computer,AOL search,Search,Broad,Broad,AOL search - Top,0,3,0.0
-2019-05-14,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-13,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,5,0.0
-2019-04-12,150175881,359751135,USD,Android,Tablet,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2019-04-10,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-04-17,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Other,0,1,0.0
-2019-04-18,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,15,0.0
-2019-04-25,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,7,0.0
-2018-11-02,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-03-27,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-30,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,0,1,0.0
-2019-04-27,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,2,0.0
-2019-05-04,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,6,0.0
-2019-05-18,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,14,0.0
-2019-05-14,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,5,0.0
-2019-05-07,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,3,0.0
-2019-05-07,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,2,0.0
-2019-05-26,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Other,0,1,0.0
-2019-04-20,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,0,1,0.0
-2019-05-24,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-23,150175881,359751135,USD,Android,Smartphone,Audience,Audience,Broad,Broad,Audience network,0,1,0.0
-2019-04-10,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,0,1,0.0
-2019-05-10,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-20,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-07,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,5,0.0
-2019-04-29,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,6,0.0
-2019-05-17,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,21,0.0
-2019-04-27,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,1,0.0
-2019-04-21,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,0,1,0.0
-2019-04-21,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,2,0.0
-2019-04-15,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,2,0.0
-2019-05-26,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,5,0.0
-2019-04-08,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,3,0.0
-2019-04-25,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,3,0.0
-2019-04-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-01-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Other,0,1,0.0
-2019-05-08,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-13,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,2,0.0
-2019-05-05,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,8,0.0
-2018-10-16,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2019-05-05,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-18,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,2,0.0
-2019-05-22,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,4,0.0
-2019-04-08,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,3,0.0
-2019-04-17,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,0,1,0.0
-2019-04-21,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,6,0.0
-2019-04-18,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,6,0.0
-2019-05-22,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,0,1,0.0
-2018-09-20,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-04,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-03,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-07,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-02,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,0,1,0.0
-2019-05-08,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,20,0.0
-2019-05-03,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,24,0.0
-2019-05-23,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,0,1,0.0
-2019-04-17,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,15,0.0
-2019-04-20,150175881,359751135,USD,iOS,Tablet,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2019-04-25,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,4,0.0
-2019-04-16,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,6,0.0
-2019-05-23,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,2,0.0
-2018-10-23,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,2,0.0
-2018-10-25,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-13,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-04-26,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-03,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,8,0.0
-2019-04-09,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,3,0.0
-2019-05-26,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-23,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,6,0.0
-2018-11-13,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2019-04-05,150175881,359751135,USD,iOS,Tablet,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,2,0.0
-2019-05-12,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,2,0.0
-2019-05-01,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,2,0.0
-2019-05-16,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,3,0.0
-2019-04-19,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,2,0.0
-2019-05-24,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,6,0.0
-2019-04-25,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,5,0.0
-2019-04-16,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,16,0.0
-2018-11-22,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,2,0.0
-2018-12-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,1,0.0
-2018-10-05,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-20,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-05-07,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,28,0.0
-2019-05-27,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-17,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,11,0.0
-2019-05-23,150175881,359751135,USD,iOS,Tablet,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,2,0.0
-2019-03-12,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2018-10-05,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2019-04-26,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-16,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,7,0.0
-2019-04-29,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,18,0.0
-2019-04-09,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2019-04-25,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,2,0.0
-2018-12-18,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-01-25,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-17,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,10,0.0
-2019-05-01,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-19,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-04,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,2,0.0
-2019-04-12,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,1,0.0
-2019-04-08,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-04-11,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,3,0.0
-2019-05-23,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-15,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-04-16,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,0,4,0.0
-2019-04-24,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,6,0.0
-2019-04-19,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,12,0.0
-2018-11-20,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-02-04,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-06,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-03,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,3,0.0
-2019-05-07,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,1,0.0
-2019-05-25,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-13,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2019-05-17,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,10,0.0
-2019-05-04,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,5,0.0
-2019-05-23,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,3,0.0
-2019-04-11,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-04-14,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,2,0.0
-2019-05-22,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,8,0.0
-2019-04-25,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,3,0.0
-2019-05-16,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,6,0.0
-2019-05-13,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-15,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2019-05-03,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-21,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2019-05-10,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,1,0.0
-2019-04-20,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-05-23,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,7,0.0
-2019-05-24,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,27,0.0
-2019-05-23,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,18,0.0
-2019-04-25,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,0,2,0.0
-2019-03-31,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-29,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,4,0.0
-2019-05-05,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-27,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-05-01,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-10-09,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-04-26,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,7,0.0
-2019-04-28,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-06,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,0,3,0.0
-2019-04-11,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,4,0.0
-2019-04-21,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,27,0.0
-2019-04-19,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,3,0.0
-2019-04-09,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-04-17,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,25,0.0
-2019-05-15,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-19,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,19,0.0
-2019-04-11,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-11,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,4,0.0
-2019-04-17,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,2,0.0
-2019-04-24,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,7,0.0
-2019-03-14,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-14,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Other,0,1,0.0
-2019-05-13,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-09,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,2,0.0
-2019-04-20,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-04-09,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,0,1,0.0
-2019-04-23,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2018-10-24,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-04-16,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,2,0.0
-2019-05-01,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-21,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Other,0,1,0.0
-2019-05-06,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-17,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,1,0.0
-2019-05-08,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,2,0.0
-2019-05-09,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,6,0.0
-2019-05-08,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,47,0.0
-2019-04-16,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,5,0.0
-2019-04-14,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2019-04-10,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2019-03-19,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-09,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-21,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2019-04-27,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,2,0.0
-2019-04-30,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,28,0.0
-2019-05-10,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-16,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,7,0.0
-2019-05-18,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,4,0.0
-2019-05-18,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,6,0.0
-2019-05-14,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,3,0.0
-2019-05-12,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,5,0.0
-2019-05-27,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2019-04-24,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-26,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,1,0.0
-2019-04-01,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,2,0.0
-2019-05-18,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-05-28,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-01,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-23,150175881,359751135,USD,iOS,Tablet,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Other,0,1,0.0
-2019-02-15,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-07,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-19,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,2,0.0
-2019-05-20,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,10,0.0
-2019-05-13,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-01,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,2,0.0
-2019-05-02,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,3,0.0
-2019-05-27,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,8,0.0
-2019-05-22,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Other,0,1,0.0
-2019-04-18,150175881,359751135,USD,iOS,Tablet,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Other,0,1,0.0
-2019-04-24,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,3,0.0
-2019-05-24,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,2,0.0
-2019-04-19,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,2,0.0
-2019-04-15,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,2,0.0
-2019-05-20,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-06,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-10-16,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-19,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,3,0.0
-2019-05-13,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-08,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,3,0.0
-2019-04-28,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,1,0.0
-2019-05-06,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-07,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,4,0.0
-2019-05-01,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,3,0.0
-2019-04-29,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,4,0.0
-2019-04-22,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-04-09,150175881,359751135,USD,Android,Tablet,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Other,0,1,0.0
-2019-04-08,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2019-05-23,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-23,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-25,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,46,0.0
-2019-05-23,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,4,0.0
-2019-05-27,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2018-12-05,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-02-04,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-22,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2019-04-29,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-14,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-25,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-28,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2019-05-01,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-28,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,4,0.0
-2019-04-24,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,0,3,0.0
-2019-04-22,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,2,0.0
-2019-05-06,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,3,0.0
-2019-05-18,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-09,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-10,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-16,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,16,0.0
-2019-04-15,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,3,0.0
-2019-04-19,150175881,359751135,USD,iOS,Tablet,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Other,0,1,0.0
-2019-04-17,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,3,0.0
-2019-05-23,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,2,0.0
-2019-05-22,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,4,0.0
-2019-05-20,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,2,0.0
-2019-04-29,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-07,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-05,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,10,0.0
-2019-04-29,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,3,0.0
-2019-05-10,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-14,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-05-23,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-04-22,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-04-23,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-18,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-04-23,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,1,0.0
-2019-03-29,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,2,0.0
-2019-02-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,2,0.0
-2019-05-14,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Other,0,1,0.0
-2018-10-12,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-08,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,3,0.0
-2019-05-06,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,2,0.0
-2019-05-05,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2019-05-16,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,20,0.0
-2019-04-20,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-23,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,2,0.0
-2019-04-24,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,2,0.0
-2019-03-14,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-23,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-04,150175881,359751135,USD,Android,Tablet,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Other,0,1,0.0
-2019-04-27,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,2,0.0
-2019-05-03,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,3,0.0
-2019-05-17,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,3,0.0
-2019-05-10,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,2,0.0
-2019-05-22,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-22,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,4,0.0
-2019-05-22,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-04-15,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,1,0.0
-2019-04-20,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,20,0.0
-2019-02-04,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-10,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-26,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2019-05-06,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,4,0.0
-2019-04-30,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,2,0.0
-2019-04-21,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,2,0.0
-2019-05-23,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,4,0.0
-2019-05-09,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,4,0.0
-2019-04-30,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,2,0.0
-2019-04-29,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,14,0.0
-2019-05-07,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-18,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,2,0.0
-2019-05-05,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,12,0.0
-2019-05-17,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,5,0.0
-2019-04-11,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,4,0.0
-2019-04-14,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,4,0.0
-2019-04-22,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,4,0.0
-2019-05-23,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-22,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,26,0.0
-2018-10-28,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,1,0.0
-2019-03-12,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,0,1,0.0
-2019-04-25,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2019-05-14,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-20,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,1,0.0
-2019-05-16,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-12,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,2,0.0
-2019-04-11,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,3,0.0
-2019-04-10,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-04-24,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,3,0.0
-2019-05-26,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-20,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,2,0.0
-2019-04-17,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,6,0.0
-2019-03-08,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2019-04-28,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2019-05-02,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,11,0.0
-2019-05-19,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,1,0.0
-2019-05-19,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-27,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-07,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-04,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-26,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,2,0.0
-2019-05-01,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,0,1,0.0
-2019-05-07,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-16,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,8,0.0
-2019-04-19,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,0,1,0.0
-2019-04-11,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,6,0.0
-2019-04-24,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,34,0.0
-2019-05-02,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2019-01-25,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-20,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,14,0.0
-2019-05-14,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-07,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,4,0.0
-2019-05-06,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,3,0.0
-2019-05-09,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,2,0.0
-2019-05-18,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,25,0.0
-2019-04-13,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,0,4,0.0
-2019-04-13,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,2,0.0
-2019-04-14,150175881,359751135,USD,iOS,Tablet,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,1,0.0
-2019-04-22,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,0,15,0.0
-2019-05-08,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,1,20,7.0
-2019-05-22,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,2,40,17.82
-2019-04-18,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,1,20,9.7
-2019-05-02,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,1,20,5.36
-2019-04-23,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,3,48,5.6
-2019-05-11,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,1,16,5.09
-2019-05-25,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,1,10,5.92
-2019-05-03,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,1,10,6.23
-2019-05-12,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,1,8,1.91
-2019-05-28,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,1,8,4.91
-2019-05-25,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,1,8,7.2
-2019-05-14,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,4,32,20.47
-2019-05-23,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,3,20,17.01
-2019-05-15,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,3,15,25.8
-2019-04-09,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,1,4,0.51
-2019-05-16,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,1,4,0.86
-2019-05-06,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,1,4,9.31
-2019-05-24,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,1,4,6.04
-2019-05-16,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,1,2,8.82
-2018-10-09,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,1,1,5.6
-2018-09-19,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,1,1,0.5
-2019-04-28,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,1,1,5.19
-2018-10-05,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,1,1,1.08
-2019-04-14,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,1,1,2.93
-2019-03-29,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,2,2,3.6
-2019-04-23,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,1,1,7.85
-2019-05-14,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,1,1,1.65
-2019-04-12,150175881,359751135,USD,Android,Tablet,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,1,1,8.12
-2019-05-24,150175881,359751135,USD,Android,Tablet,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Other,1,1,1.57
-2019-05-14,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,1,47,4.0
-2019-05-12,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,1,42,5.02
-2019-05-09,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,2,47,1.52
-2019-05-02,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,1,21,9.24
-2019-05-25,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,1,3,5.84
-2019-05-21,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,2,6,11.49
-2019-05-06,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,1,7,4.12
-2019-04-15,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,2,24,14.48
-2019-04-30,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,1,12,1.48
-2019-05-20,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,1,22,5.64
-2019-04-27,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,5,180,6.18
-2019-04-19,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,1,18,3.62
-2019-04-26,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,3,54,3.86
-2019-05-12,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,3,22,11.28
-2019-05-06,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,1,46,0.7
-2019-05-06,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,1,23,0.65
-2019-04-25,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,1,23,6.5
-2019-04-25,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,5,170,7.53
-2019-05-17,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,2,41,17.44
-2019-05-10,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,2,17,1.53
-2019-05-13,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,4,38,25.56
-2019-05-01,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,2,19,10.29
-2019-05-10,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,1,28,4.76
-2019-04-30,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,1,28,5.95
-2019-05-09,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,1,28,2.65
-2019-05-20,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,1,28,5.69
-2019-05-01,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,1,28,6.57
-2019-05-13,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,2,28,7.13
-2019-05-14,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,2,74,9.83
-2019-04-29,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,4,116,6.42
-2019-05-10,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,1,29,6.73
-2019-04-27,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,2,29,1.12
-2019-04-22,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,1,54,1.5
-2019-04-21,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,1,48,2.34
-2019-04-23,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,6,195,16.27
-2019-04-20,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,5,39,16.69
-2019-05-06,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,1,24,9.91
-2019-04-26,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,11,203,15.18
-2019-05-11,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,1,15,5.03
-2019-04-26,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,1,15,7.94
-2019-04-18,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,1,9,4.06
-2019-05-24,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,1,9,4.1
-2019-05-07,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,2,9,1.62
-2019-04-19,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,2,26,8.6
-2019-04-15,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,1,13,5.96
-2019-05-09,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,2,26,6.19
-2019-05-19,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,1,13,4.81
-2019-05-21,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,2,26,13.68
-2019-05-13,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,2,77,6.73
-2019-04-12,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,1,6,9.72
-2019-04-10,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,1,6,6.95
-2019-05-03,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,1,6,7.56
-2019-05-10,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,1,6,8.7
-2019-05-13,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,1,6,8.62
-2019-05-02,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,1,6,9.73
-2019-04-28,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,3,71,1.21
-2019-04-28,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,8,189,6.79
-2019-04-24,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,1,178,3.17
-2018-11-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-27,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-01-03,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2019-01-07,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-09,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2018-11-21,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-07,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-21,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-09,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-03,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2018-10-28,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,0,0.0
-2019-03-12,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-13,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-27,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2018-11-26,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-18,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-20,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-09,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-26,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2018-10-13,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,0,0.0
-2018-12-02,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-01,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-14,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-02,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-03,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2018-10-07,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2018-11-16,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-01,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-16,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,0,0.0
-2019-05-15,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2019-05-23,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-14,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2019-04-24,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-16,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-09,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,0,0.0
-2019-03-22,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2018-09-17,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,0,0.0
-2019-05-26,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-18,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-01-21,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,0,0.0
-2019-04-22,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-19,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2018-11-11,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-08,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-14,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-13,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2018-09-17,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,0,0.0
-2019-02-07,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,0,0.0
-2018-12-06,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2018-11-22,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-17,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2019-04-24,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-01-10,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2019-04-27,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,0,0.0
-2019-03-19,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-17,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,0,0.0
-2019-02-14,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-23,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-01-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-03,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-23,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2018-12-15,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2018-10-06,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2019-05-27,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-01-06,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2018-09-25,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-18,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-26,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-10,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-18,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-09,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-18,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2019-02-24,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2018-11-29,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-20,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-10,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-11,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2019-03-04,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2018-11-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-03,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-29,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-21,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2019-03-02,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-13,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2019-03-14,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2018-10-03,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-30,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,0,0.0
-2018-12-22,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,0,0.0
-2019-03-22,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-03,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,0,0.0
-2018-11-11,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2019-05-09,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2019-04-16,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-29,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-12,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2018-11-10,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-13,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-24,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,0,0.0
-2018-10-07,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2019-03-23,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-01-26,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-25,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-23,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-30,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-18,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2018-12-03,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-11,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-09,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-08,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-01-20,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-16,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2018-09-24,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-22,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-06,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-10,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2019-03-25,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2019-04-07,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-30,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-22,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-13,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,0,0.0
-2019-02-04,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-17,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,0,0.0
-2019-03-17,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-10,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-27,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2018-11-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2019-05-09,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2019-04-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-21,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-03,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,0,0.0
-2018-12-02,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2018-10-17,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-01,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-01,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-14,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2018-12-22,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,0,0.0
-2019-04-03,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-01-09,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2019-05-15,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2018-10-06,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,0,0.0
-2018-11-13,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,0,0.0
-2019-03-05,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2018-10-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2019-03-24,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2019-04-19,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2019-02-18,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-01-08,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2019-01-05,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2018-10-18,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-04,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,0,0.0
-2018-11-10,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-07,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-01-05,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-09,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-11,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-14,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2019-01-03,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-01-02,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-08,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2018-11-30,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-02,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,0,0.0
-2018-11-26,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,0,0.0
-2019-04-28,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-01-27,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-18,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2019-02-16,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-18,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-14,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-01-10,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2018-12-11,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-01,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-06,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2019-05-12,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-12,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-26,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-24,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-14,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2018-11-27,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2019-05-16,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,0,0.0
-2019-03-25,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-07,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-12,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-11-09,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2018-12-13,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-17,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-07,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-03-29,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2018-12-20,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-02-20,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2019-04-19,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2018-11-01,150175881,349886458,USD,iOS,Tablet,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,3,0.0
-2018-12-20,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,2,0.0
-2018-09-20,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,2,0.0
-2018-11-27,150175881,349886458,USD,Android,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-07,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-03-29,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-02-01,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,2,0.0
-2018-10-12,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2019-01-10,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2018-12-11,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-09-25,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2018-09-21,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-02-25,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,2,0.0
-2019-02-17,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-25,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-12-15,150175881,349886458,USD,iOS,Tablet,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-03-22,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2019-05-18,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-04-05,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,4,0.0
-2019-05-26,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,3,0.0
-2019-01-10,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,5,0.0
-2019-03-11,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,5,0.0
-2018-11-05,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,4,0.0
-2018-09-18,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,2,0.0
-2018-09-24,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,1,0.0
-2018-09-18,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2019-03-19,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,1,0.0
-2019-04-07,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-08,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2019-03-15,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,2,0.0
-2019-02-27,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2018-10-22,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,3,0.0
-2018-12-20,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2018-09-23,150175881,349886458,USD,Android,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-06,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-04-20,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-01-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,1,0.0
-2019-03-10,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2018-11-21,150175881,349886458,USD,Android,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-03-01,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,3,0.0
-2018-10-23,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2018-11-08,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-03-15,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-10-02,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-04-25,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-01-24,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,5,0.0
-2019-02-19,150175881,349886458,USD,iOS,Tablet,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-03-23,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-01,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-03-22,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-01-08,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,5,0.0
-2019-04-15,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-03-14,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2018-10-04,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-01-25,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-03-18,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2019-04-23,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,3,0.0
-2019-02-22,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2018-12-21,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,2,0.0
-2019-05-13,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-19,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-10-10,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2018-12-11,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-02-14,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-27,150175881,349886458,USD,iOS,Tablet,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-03-27,150175881,349886458,USD,Android,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-20,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,3,0.0
-2019-04-29,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2018-11-04,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-01-22,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-04-12,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2019-04-18,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2018-10-18,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,2,0.0
-2018-10-09,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2019-02-06,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2018-10-09,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-12-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,1,0.0
-2019-03-02,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-02-08,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,3,0.0
-2019-02-14,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,2,0.0
-2018-11-22,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-03-15,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2018-09-26,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-09-24,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-12-04,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,2,0.0
-2019-03-29,150175881,349886458,USD,Android,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-01-07,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-01-28,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-01-03,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,3,0.0
-2019-03-20,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-08,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-02-26,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-03-04,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,5,0.0
-2018-12-13,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2018-12-01,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-02-25,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,6,0.0
-2019-05-10,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,3,0.0
-2019-02-13,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-01-28,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-02-10,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-17,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2018-10-16,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,3,0.0
-2019-03-02,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2018-10-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2018-09-21,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2019-05-03,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,5,0.0
-2019-02-11,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2018-11-05,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,4,0.0
-2019-04-10,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2018-12-14,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,1,0.0
-2019-04-24,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,2,0.0
-2018-11-28,150175881,349886462,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2018-10-19,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-11-19,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-10-22,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,2,0.0
-2018-10-28,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2018-10-02,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,1,0.0
-2018-12-25,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-04-24,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,3,0.0
-2019-04-24,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-06,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,5,0.0
-2019-02-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,2,0.0
-2018-10-15,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,1,0.0
-2019-02-05,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2018-09-24,150175881,349886458,USD,Android,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2018-10-16,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,1,0.0
-2019-03-18,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,2,0.0
-2018-12-14,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-03-26,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-08,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-08,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,3,0.0
-2019-04-30,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-03,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-03-20,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-07,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,2,0.0
-2018-10-09,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,3,0.0
-2019-02-19,150175881,349886462,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-03-09,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-10-23,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2018-11-13,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-03-14,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-12-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,6,0.0
-2019-04-17,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2019-05-01,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2019-05-08,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-02-15,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-02-12,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-12-21,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,3,0.0
-2019-02-11,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-04-15,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,3,0.0
-2019-02-23,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2018-10-20,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-10-23,150175881,349886458,USD,Android,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2018-11-14,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2019-03-05,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-03-18,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2018-12-24,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-12-16,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-04-27,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-23,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2018-12-05,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,2,0.0
-2018-10-09,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-10-17,150175881,349886458,USD,iOS,Tablet,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2018-10-17,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,3,0.0
-2018-12-03,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2018-11-14,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-02-24,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-04-09,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-04-15,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,3,0.0
-2018-10-07,150175881,349886458,USD,iOS,Tablet,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2019-01-25,150175881,349886458,USD,Android,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-03-29,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-03-28,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,3,0.0
-2019-03-17,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,4,0.0
-2018-10-30,150175881,349886458,USD,iOS,Tablet,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-03-07,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-09-19,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-03-27,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,4,0.0
-2019-04-11,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-12-26,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,2,0.0
-2019-03-20,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,3,0.0
-2019-05-02,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-30,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2018-10-11,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-11-15,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-02-26,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-03-20,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,1,0.0
-2019-05-23,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2018-12-06,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2019-02-19,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-01-27,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,3,0.0
-2018-12-03,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,3,0.0
-2018-10-26,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,3,0.0
-2018-11-22,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,4,0.0
-2018-10-03,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2019-04-03,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-02-23,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-03-31,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-06,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2019-02-13,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-20,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-20,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,4,0.0
-2019-03-04,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2018-10-19,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2019-02-28,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-03-05,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2019-03-19,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2019-03-19,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-12-24,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,3,0.0
-2019-03-29,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2018-10-16,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2018-11-22,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2018-10-24,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-17,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-02-01,150175881,349886458,USD,iOS,Tablet,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-04-02,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,3,0.0
-2018-10-17,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,4,0.0
-2018-11-13,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-11-07,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2018-11-07,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-03-13,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-09-25,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,1,0.0
-2018-09-24,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-01-03,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,4,0.0
-2019-04-10,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2019-04-25,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-01-02,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-04-09,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-14,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2018-12-05,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,6,0.0
-2018-10-15,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,3,0.0
-2018-09-24,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,2,0.0
-2019-05-02,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,7,0.0
-2019-01-03,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-11-02,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-26,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-04-29,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-02-13,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-02-20,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-01-25,150175881,349886458,USD,iOS,Tablet,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-02-11,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-02-18,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2019-05-22,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2018-10-11,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-10-10,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,4,0.0
-2018-10-17,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2018-09-17,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2018-12-27,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2019-02-07,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-12-06,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,3,0.0
-2018-10-22,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,1,0.0
-2018-09-20,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,1,0.0
-2018-12-05,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,1,0.0
-2018-12-11,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,1,0.0
-2018-10-26,150175881,349886458,USD,Windows,Computer,AOL search,Search,Exact,Exact,AOL search - Top,0,1,0.0
-2019-02-22,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2018-10-29,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2019-03-27,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-14,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-24,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,2,0.0
-2019-04-16,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-02,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-04-08,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-02-06,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2019-04-04,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,3,0.0
-2019-02-21,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-03-10,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2018-10-30,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-02-25,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2018-09-20,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-09-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,3,0.0
-2019-02-16,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-24,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-01-23,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,1,0.0
-2019-05-23,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,3,0.0
-2019-04-15,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2018-11-02,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-11-15,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2019-03-07,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,3,0.0
-2019-03-15,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,1,0.0
-2019-03-05,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,3,0.0
-2019-03-14,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,2,0.0
-2019-01-23,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,3,0.0
-2019-02-06,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-22,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-10-25,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,3,0.0
-2018-11-09,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,3,0.0
-2019-01-09,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,2,0.0
-2018-10-03,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-01-25,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-04-17,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2019-05-15,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,1,0.0
-2019-03-24,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-03-28,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-02-18,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-03-20,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,3,0.0
-2019-05-21,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,3,0.0
-2018-10-22,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-04-10,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-12-24,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-01-23,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,3,0.0
-2019-01-08,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-01-04,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-23,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2019-01-21,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2019-05-21,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-01-20,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-03-11,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2018-11-24,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-02-28,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-10-30,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-03-11,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2018-09-27,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-05,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-10,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-04-24,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-11-27,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2018-10-13,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2018-10-14,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-02-28,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-11-24,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-04-26,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-04-25,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-01-26,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-03-18,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,3,0.0
-2018-10-07,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-01-23,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-03-30,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-16,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-02-13,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2018-10-15,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-04-15,150175881,349886458,USD,Android,Tablet,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-05,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-16,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,4,0.0
-2019-02-14,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2018-11-20,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2018-10-13,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-01-11,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-12-20,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2018-11-18,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-11-12,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,3,0.0
-2018-09-25,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,3,0.0
-2018-12-04,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,3,0.0
-2019-04-03,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-13,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-10-18,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,4,0.0
-2018-10-10,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,3,0.0
-2019-01-07,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,3,0.0
-2018-11-11,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-12-17,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,3,0.0
-2019-03-08,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2019-03-25,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2018-11-29,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2019-05-09,150175881,349886458,USD,Android,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2018-11-26,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2018-12-18,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2019-03-09,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-11-13,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2018-10-02,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2019-05-01,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-19,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-12-18,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,4,0.0
-2018-12-10,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,3,0.0
-2018-11-07,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-12-17,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,2,0.0
-2018-12-12,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,5,0.0
-2018-12-13,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-01-25,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,2,0.0
-2019-02-01,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-12-08,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-02-12,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2018-12-04,150175881,349886458,USD,iOS,Tablet,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,2,0.0
-2019-05-25,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2018-10-17,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2018-10-14,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2018-11-20,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2018-12-17,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2018-09-24,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-14,150175881,349886458,USD,iOS,Tablet,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-04-22,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-10-08,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,2,0.0
-2019-05-13,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,2,0.0
-2019-02-19,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2019-03-19,150175881,349886462,USD,BlackBerry,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-03-05,150175881,349886458,USD,Android,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2018-10-30,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2018-09-26,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,4,0.0
-2019-02-26,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2019-05-18,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-12-08,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,3,0.0
-2019-04-26,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-03-26,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-11-28,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2018-12-27,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-12-09,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-12-19,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-03-12,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-03,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,2,0.0
-2019-03-26,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,3,0.0
-2019-05-16,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-02-07,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-01-28,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-03,150175881,349886458,USD,iOS,Tablet,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-03-21,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-23,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,3,0.0
-2019-03-26,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,2,0.0
-2019-03-11,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,2,0.0
-2019-03-03,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-03-01,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2018-09-27,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2018-09-24,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-11-26,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,2,0.0
-2019-03-25,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-09,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-12-08,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-10-06,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-02-08,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-01-26,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2018-11-04,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-10-26,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,8,0.0
-2018-11-06,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2018-11-06,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-03,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-03-27,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-03,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-05-09,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-02-06,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,2,0.0
-2019-04-07,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-10-25,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-11-09,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-12-07,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2018-09-20,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-10-03,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,2,0.0
-2019-02-07,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2018-10-05,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-04-02,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,3,0.0
-2019-02-15,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-03-23,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,0,1,0.0
-2019-04-29,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,0,1,0.0
-2019-03-21,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,0,1,0.0
-2019-01-10,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,8,0.67
-2019-02-06,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,5,1.0
-2018-12-04,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,5,0.67
-2018-10-10,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,2,8,0.34
-2018-12-10,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,4,0.33
-2019-05-22,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,4,1.0
-2019-03-26,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,4,1.0
-2019-01-22,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,4,0.05
-2019-04-16,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,4,1.0
-2018-10-11,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,4,0.39
-2018-12-19,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,4,0.05
-2019-02-05,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,4,0.56
-2018-09-21,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,2,5,1.43
-2019-03-29,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,2,5,2.0
-2018-12-11,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,2,5,0.52
-2019-01-10,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,2,0.26
-2018-12-04,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,2,0.05
-2018-12-21,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,2,0.41
-2019-04-16,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,2,4,2.0
-2018-11-08,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,2,1.0
-2019-03-06,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,2,4,1.33
-2019-03-28,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,2,1.0
-2019-02-05,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,2,0.05
-2019-04-29,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,2,1.0
-2019-02-17,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,2,1.0
-2018-11-21,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,2,0.33
-2019-03-16,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,2,1.0
-2019-05-16,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,2,4,2.53
-2018-09-25,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,2,0.05
-2019-05-17,150175881,349886458,USD,Android,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,2,0.16
-2019-03-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,4,8,4.58
-2019-04-07,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,2,0.09
-2019-05-17,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,2,1.0
-2019-03-11,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,2,4,2.0
-2018-11-30,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,3,6,6.03
-2019-05-13,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,2,0.18
-2019-03-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,3,6,2.33
-2018-11-29,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,2,1.0
-2019-05-25,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,2,0.05
-2018-11-12,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,2,0.05
-2018-12-11,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,2,0.05
-2019-03-01,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,2,0.56
-2019-03-05,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,2,1.0
-2018-10-10,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,2,1.0
-2019-05-03,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,2,0.33
-2019-05-02,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,2,1.11
-2019-01-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,2,1.0
-2019-05-17,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,2,1.0
-2019-01-24,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,2,4,1.1
-2018-10-11,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,2,0.85
-2018-10-30,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,2,4,1.22
-2019-01-09,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,2,0.05
-2019-03-27,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,2,0.67
-2018-09-17,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,2,0.05
-2019-05-21,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,2,1.0
-2019-04-26,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,2,1.0
-2019-04-25,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,2,1.0
-2019-04-09,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,2,1.14
-2018-12-04,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,2,0.05
-2019-03-19,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,2,0.41
-2019-05-15,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,2,0.33
-2018-10-15,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,2,1.0
-2019-02-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,2,1.0
-2018-11-20,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,2,0.05
-2019-05-15,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,2,0.67
-2019-05-06,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,2,1.0
-2019-01-08,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,2,4,0.92
-2018-12-10,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,2,4,0.28
-2019-05-15,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,3,6,3.0
-2018-10-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,2,1.0
-2019-04-11,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,2,4,1.67
-2018-11-09,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,2,4,1.05
-2018-12-16,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,2,0.28
-2019-03-08,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,3,5,2.05
-2019-03-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,3,5,0.99
-2018-09-26,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,3,5,2.94
-2019-03-25,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,4,5,4.29
-2019-05-23,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,4,5,3.58
-2018-10-31,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,1,0.05
-2019-03-30,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,0.67
-2019-05-23,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,0.27
-2018-11-20,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,0.05
-2019-02-08,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,1,0.05
-2019-05-24,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,1,0.01
-2018-10-31,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,2,2,1.12
-2019-04-19,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,1.0
-2019-05-10,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,1.0
-2019-03-29,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,1,0.02
-2019-02-05,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,0.18
-2019-03-20,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,0.67
-2019-03-19,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,0.31
-2018-10-06,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,1.0
-2018-10-09,150175881,349886458,USD,iOS,Tablet,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,1,0.05
-2019-03-25,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,0.16
-2018-11-07,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,0.05
-2019-04-03,150175881,349886458,USD,iOS,Tablet,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,0.24
-2019-04-12,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,1,1.0
-2019-05-19,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,1.0
-2019-04-16,150175881,349886462,USD,Android,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,0.15
-2019-03-07,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,0.57
-2019-03-07,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,0.18
-2018-11-12,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,1,0.05
-2018-11-05,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,3,3,2.67
-2019-02-04,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,2,2,0.7
-2018-10-02,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,0.29
-2019-02-02,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,1,0.33
-2019-04-19,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,1,1.0
-2018-11-08,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,1.0
-2018-11-02,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,0.34
-2018-11-20,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,1.03
-2019-05-07,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,1.0
-2019-01-22,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,1.0
-2019-03-04,150175881,349886458,USD,Android,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,0.28
-2019-05-24,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,0.05
-2019-03-27,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,2,2,2.0
-2018-11-23,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,0.05
-2018-10-30,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,1,1,0.05
-2019-05-19,150175881,349886458,USD,Android,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,0.24
-2019-02-04,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,1,0.05
-2018-11-17,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,0.24
-2019-01-05,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,1,0.33
-2019-03-31,150175881,349886458,USD,Android,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,0.2
-2019-05-14,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,2,2,2.0
-2019-04-15,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,1.0
-2019-01-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,2,2,0.1
-2019-04-11,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,1.0
-2019-02-18,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,0.09
-2018-10-25,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,3,3,1.45
-2018-11-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,0.11
-2019-05-14,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,4.08
-2018-11-08,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,0.18
-2018-12-16,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,1,0.05
-2018-11-15,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,0.6
-2019-02-09,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,1,0.05
-2019-05-07,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,0.12
-2018-10-11,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,0.27
-2018-10-09,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,3,3,1.62
-2018-12-10,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,0.23
-2019-02-09,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,1,0.18
-2019-04-11,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,0.05
-2019-04-18,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,1,1.0
-2018-10-08,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,1,0.05
-2019-02-11,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,0.05
-2019-03-17,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,1.0
-2018-11-19,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,3,3,0.36
-2018-09-23,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,0.04
-2019-02-05,150175881,349886458,USD,Android,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,0.95
-2019-05-27,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,1,1.0
-2019-03-19,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,1,1.0
-2018-11-16,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,0.27
-2018-11-27,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,2,2,0.25
-2018-11-11,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,1.0
-2019-04-09,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,1.0
-2019-05-15,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,1.0
-2018-10-03,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,0.22
-2019-05-02,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,0.12
-2019-03-22,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,0.09
-2018-12-03,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,1,0.05
-2019-03-17,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,1,1.0
-2018-10-24,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,1,0.05
-2019-05-05,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,1,1.0
-2019-02-28,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,2,2,1.37
-2018-10-24,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,3,3,3.0
-2018-11-12,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,2,2,2.0
-2018-10-16,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,0.26
-2018-12-17,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,1.36
-2019-04-23,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,0.05
-2019-05-21,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,1.0
-2018-10-23,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,0.05
-2019-01-22,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,1.0
-2018-10-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,1.09
-2019-05-28,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,1.0
-2019-05-05,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,1.0
-2019-04-25,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,0.11
-2019-05-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,1.0
-2018-09-19,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,1,0.05
-2018-09-19,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,2,2,0.56
-2018-10-15,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,0.05
-2018-12-18,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,2,2,0.66
-2019-02-27,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,0.3
-2019-04-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,1,1.0
-2019-05-18,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,2,1,0.66
-2019-05-08,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,5,8,5.0
-2018-11-28,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,3,4,1.57
-2019-03-12,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,3,4,1.68
-2019-05-14,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,3,4,6.57
-2019-02-26,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,3,4,1.1
-2018-11-01,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,3,4,1.24
-2018-10-05,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,3,4,2.47
-2019-04-10,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,3,1.0
-2019-02-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,3,0.32
-2019-01-02,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,3,0.05
-2019-04-30,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,2,6,2.0
-2018-11-06,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,3,0.33
-2019-02-14,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,2,6,1.0
-2019-01-10,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,3,0.01
-2019-05-12,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,3,1.0
-2019-04-03,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,3,1.0
-2018-10-09,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,3,0.11
-2019-02-21,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,3,1.0
-2018-12-14,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,3,0.11
-2019-05-20,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,3,1.0
-2019-01-21,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,3,4.18
-2018-10-12,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,3,0.14
-2019-03-28,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,3,1.25
-2019-02-20,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,3,0.08
-2019-01-26,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,3,0.05
-2019-05-09,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,3,0.33
-2018-12-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,3,0.05
-2018-12-07,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,3,0.33
-2019-05-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,3,1.0
-2018-10-09,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,2,6,1.19
-2019-01-07,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,3,0.33
-2019-02-21,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,3,1.0
-2019-02-19,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,3,0.67
-2018-11-27,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,2,6,0.56
-2018-11-15,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,3,0.29
-2018-10-16,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,3,0.39
-2019-04-27,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,3,1.0
-2018-11-30,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,3,0.33
-2018-12-05,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,3,0.05
-2019-03-07,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,3,0.33
-2018-10-12,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,3,0.05
-2019-02-07,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,2,7,1.21
-2019-05-02,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,2,7,1.67
-2019-04-08,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,2,3,0.23
-2019-05-09,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,2,3,1.43
-2019-04-01,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,2,3,2.0
-2019-01-23,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,2,3,0.71
-2019-03-26,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,2,3,1.21
-2019-03-18,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,2,3,1.33
-2019-03-05,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,2,3,1.59
-2019-04-17,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,2,3,2.0
-2019-02-20,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,2,3,1.39
-2019-04-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,2,3,2.63
-2019-03-27,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,2,3,2.0
-2018-10-18,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,9,2.32
-2019-02-26,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,1,6,0.05
-2018-12-05,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,1,6,0.17
-2019-01-23,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-03-26,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-20,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-24,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-02,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-01,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2018-12-09,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-05-16,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-08,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-22,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-12,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-10-13,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-11-11,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-10,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-10-25,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2018-09-23,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-12,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-03-27,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-04-15,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-12,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-10-10,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-24,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-29,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-18,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-01,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-19,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-10-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-02-12,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-05,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-26,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-24,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-10-18,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-10-30,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-13,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-18,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-03-29,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-04-03,150175881,349886458,USD,iOS,Tablet,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-24,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-01,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-31,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-04-23,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,0,0.0
-2019-03-22,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-10,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-09,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-08,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2018-10-08,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-13,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-04-05,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-17,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-25,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-08,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2018-10-15,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-01-10,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-20,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-29,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-03,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-08,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-10-21,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-10-20,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,0,0.0
-2018-12-18,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-20,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-04-28,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-17,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-02-23,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-13,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-12,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-06,150175881,349886462,USD,Unknown,Computer,AOL search,Search,Phrase,Phrase,AOL search - Top,0,0,0.0
-2018-11-02,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2018-09-22,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-28,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,0,0.0
-2019-05-18,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-25,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-23,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-11-29,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-17,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-02-07,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-14,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-02-27,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-28,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-04-05,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-09-24,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-21,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-11-26,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-17,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-19,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-18,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-27,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2018-12-13,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-04-10,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-01,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-30,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-14,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,0,0.0
-2018-12-13,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-09,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2018-11-25,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,0,0.0
-2018-12-07,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-08,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2018-12-08,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-10-24,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-04,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-01-06,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-01-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-03-20,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-26,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-10,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-29,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2018-10-28,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-11-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-10-26,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2018-12-14,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-19,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-03,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-04-29,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-05,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-26,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-09,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2018-09-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-12,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2018-09-17,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-06,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,0,0.0
-2019-04-24,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-15,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-24,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-12,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2018-10-09,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2018-12-11,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-10,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-11-03,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-01-10,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-09,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-23,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-09,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-14,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2018-12-06,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2018-12-10,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-03-29,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-12,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-22,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,0,0.0
-2019-04-21,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-06,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-01,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-05,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-04-03,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-09-18,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-14,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-05,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-03-20,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-14,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-14,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2018-12-07,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-11-03,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-16,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-11-08,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-04,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-03-21,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-27,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-09,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-14,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-13,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-27,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-11,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-09,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-14,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-15,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-11-03,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-02-27,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2018-12-18,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-19,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-03-24,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-16,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,0,0.0
-2018-09-23,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-08,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-27,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-12,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-10-27,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-09-20,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-13,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-11,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-23,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-10-12,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-01-05,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-04,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-16,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-14,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-11-01,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2018-09-22,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-05-27,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-10-22,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-04-10,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-10-26,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-17,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-07,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-04-04,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-05-12,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-25,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-10-13,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2018-10-21,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,0,0.0
-2018-12-12,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-19,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-15,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-06,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-12,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-04-01,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-02-28,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-09-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-03,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-01-23,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-08,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-14,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-02-20,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-02-13,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-10-14,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-20,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-09,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-01,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-22,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-11,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-09,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-10-03,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-28,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2018-10-20,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-13,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-05-13,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-20,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-03,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2018-12-07,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-11,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2018-12-16,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-21,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-12,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-07,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2018-12-19,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-05-21,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,0,0.0
-2019-05-27,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-13,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-19,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,0,0.0
-2019-04-02,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-24,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-28,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-03,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-21,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-09,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-04-29,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-10-18,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-04-09,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-02,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-16,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2018-10-12,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-01,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-10-23,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-13,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,0,0.0
-2018-12-06,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-08,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-10-09,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2018-10-16,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-01-07,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-07,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-11,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-25,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-02,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-07,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-10-10,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-11-27,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-04-19,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-08,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-02-13,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-11-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2018-12-11,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-03-27,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-17,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-08,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-03-01,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-09-24,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-04,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2018-12-25,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-01-23,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2018-12-07,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-04-09,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-01-06,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-25,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-14,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2018-10-29,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-17,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-23,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-28,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-27,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,0,0.0
-2019-02-14,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-06,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-04-29,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-11-04,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-17,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-03-10,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-09,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-09,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-08,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-04,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-04,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-21,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-04-12,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-10,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-09,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-01-23,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-05-23,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-15,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-27,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-08,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-03-10,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-10-30,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-04-09,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-10-15,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-04,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-07,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-06,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-01-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-02,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,0,0.0
-2019-04-30,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-28,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-11-25,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,0,0.0
-2018-12-10,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-02,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-01-08,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-05,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-05-16,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-15,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-03-05,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-14,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-02,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-03-18,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-05-07,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-02,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-08,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-10-17,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-06,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-03-05,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-10,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-04-08,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-08,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-04-03,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2018-09-24,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-04-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,0,0.0
-2019-05-20,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-12-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2019-02-08,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,0,0.0
-2018-11-06,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-11-16,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-10-24,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-02-19,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,3,0.0
-2018-10-09,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,2,0.0
-2018-11-13,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,4,0.0
-2018-11-13,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-12-03,150175881,349886458,USD,iOS,Tablet,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-03-12,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-01-27,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-01-22,150175881,349886458,USD,Android,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-10,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-03-18,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2018-12-15,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-03-19,150175881,349886458,USD,Android,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-03-27,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,3,0.0
-2018-12-05,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,2,0.0
-2018-10-22,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,4,0.0
-2018-12-12,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2018-11-08,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-03-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,1,0.0
-2018-12-06,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-02-28,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,5,0.0
-2018-09-21,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-12-05,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-05-04,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-04-08,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,3,0.0
-2019-04-29,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-02-14,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2018-12-07,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-04-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-04,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-01-07,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-01-09,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-11-09,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-03-15,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-11,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,4,0.0
-2019-04-09,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,4,0.0
-2018-12-05,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,14,0.0
-2018-11-13,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2018-11-19,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2018-12-18,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-10-26,150175881,349886458,USD,Windows,Computer,AOL search,Search,Phrase,Phrase,AOL search - Top,0,3,0.0
-2018-12-21,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-12-16,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2018-12-06,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,2,0.0
-2019-03-05,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-02-27,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-12-20,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,3,0.0
-2018-11-07,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2018-09-21,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-02-11,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,3,0.0
-2018-12-27,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-09,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-02-21,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-10-10,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-03-08,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-04-07,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-01-27,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-01-04,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,3,0.0
-2019-02-13,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-04-17,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,7,0.0
-2019-05-17,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-02-22,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-02-20,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-03-28,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2018-12-06,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,6,0.0
-2018-10-09,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,3,0.0
-2018-10-15,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,1,0.0
-2019-03-06,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,6,0.0
-2018-12-03,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-01-08,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,3,0.0
-2018-10-02,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-01-03,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-04-25,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,3,0.0
-2019-04-26,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-10,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2018-11-20,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2018-12-05,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-02-23,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-02-07,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-02-21,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,2,0.0
-2019-02-06,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-12-10,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,6,0.0
-2018-10-23,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-09-18,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,3,0.0
-2018-10-07,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-03-20,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-03-27,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-03,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-01-25,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-03-31,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-02-14,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-01-07,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-02-27,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,3,0.0
-2019-03-14,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-12-10,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,5,0.0
-2018-09-26,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-07,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-21,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-02-01,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-10-10,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,1,0.0
-2019-03-13,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2018-12-20,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-11-02,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-03-12,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,3,0.0
-2019-03-12,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2018-12-04,150175881,349886458,USD,iOS,Tablet,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,3,0.0
-2019-03-27,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,9,0.0
-2018-12-04,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,3,0.0
-2019-04-24,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,2,0.0
-2019-02-22,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-04-06,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-02-11,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2018-12-17,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,5,0.0
-2018-11-09,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-10-24,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-11-20,150175881,349886458,USD,iOS,Tablet,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-10-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2018-10-04,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,2,0.0
-2019-04-09,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,5,0.0
-2019-03-04,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,5,0.0
-2019-02-26,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2018-09-26,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2018-11-26,150175881,349886458,USD,iOS,Tablet,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-03-18,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,4,0.0
-2019-04-23,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,5,0.0
-2019-04-22,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-04-15,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-03-31,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2018-12-05,150175881,349886462,USD,Unknown,Computer,AOL search,Search,Phrase,Phrase,AOL search - Top,0,3,0.0
-2018-09-19,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,4,0.0
-2019-03-28,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-03,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-18,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,3,0.0
-2019-04-02,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-14,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-03,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-03-24,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,3,0.0
-2019-05-20,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,6,0.0
-2019-01-22,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,2,0.0
-2018-12-20,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,4,0.0
-2019-04-02,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,5,0.0
-2018-11-30,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-02-04,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-10-05,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-12-26,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-02-09,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-24,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-10-30,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,3,0.0
-2018-11-06,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,3,0.0
-2019-02-26,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,6,0.0
-2018-12-21,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,1,0.0
-2019-05-13,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-04-28,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-02-11,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-02-01,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,1,0.0
-2019-03-26,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2018-10-17,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,1,0.0
-2018-11-14,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,5,0.0
-2019-03-05,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-12-03,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,5,0.0
-2019-03-15,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-02-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,1,0.0
-2019-01-24,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-03-29,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-01-19,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-19,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-04-02,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-24,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-12-21,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-20,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,3,0.0
-2019-05-26,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-03-22,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-04-30,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-04-16,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,2,0.0
-2018-10-10,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,3,0.0
-2018-10-11,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2018-10-23,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-11-28,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,3,0.0
-2019-02-11,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-01-03,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,1,0.0
-2018-10-16,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-10-23,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-03-06,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-11-18,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-02-18,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,4,0.0
-2019-04-18,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,4,0.0
-2019-05-25,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-11-04,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-04-17,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2018-12-02,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-12-11,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,2,0.0
-2018-12-27,150175881,349886458,USD,iOS,Tablet,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-04-24,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-02-15,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-04-15,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-02-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-04,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,7,0.0
-2018-11-15,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-03-15,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-01-09,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-02-04,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2018-11-27,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,3,0.0
-2019-04-18,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,3,0.0
-2019-03-18,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,1,0.0
-2019-05-24,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-01-25,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-04-15,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-10-16,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2018-10-17,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,2,0.0
-2018-12-20,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-01-27,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-03-25,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,7,0.0
-2019-05-01,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-02-05,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,4,0.0
-2019-04-15,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,2,0.0
-2018-10-11,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-02-15,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-03-11,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-13,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,3,0.0
-2019-04-05,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,3,0.0
-2018-12-06,150175881,349886458,USD,Windows,Computer,AOL search,Search,Phrase,Phrase,AOL search - Top,0,1,0.0
-2019-04-26,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,3,0.0
-2018-11-26,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-04-17,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,5,0.0
-2019-02-01,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-07,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-04-24,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,2,0.0
-2019-03-14,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,8,0.0
-2018-11-03,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-02-10,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,1,0.0
-2019-02-01,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-07,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2018-12-07,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,2,0.0
-2018-10-10,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,3,0.0
-2019-03-05,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,3,0.0
-2019-03-03,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-12-05,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,8,0.0
-2018-09-20,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,2,0.0
-2019-01-20,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-02-24,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-04-30,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,3,0.0
-2019-02-21,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-12-08,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,1,0.0
-2018-12-05,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,85,0.0
-2019-05-06,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,8,0.0
-2019-03-01,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-01-06,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-12-20,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,1,0.0
-2019-03-29,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,4,0.0
-2019-02-04,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-01-24,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-23,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-14,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,5,0.0
-2019-04-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,2,0.0
-2018-10-11,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-03-12,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-03-03,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-10,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-04-30,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-04-12,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,4,0.0
-2019-02-21,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2018-10-03,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,4,0.0
-2018-11-28,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-01-03,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2018-12-19,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,3,0.0
-2019-03-31,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2018-10-20,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,1,0.0
-2018-09-19,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,4,0.0
-2018-09-18,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-04-11,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,4,0.0
-2018-11-24,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2018-12-17,150175881,349886458,USD,iOS,Tablet,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-12-05,150175881,349886462,USD,Windows,Computer,AOL search,Search,Phrase,Phrase,AOL search - Top,0,1,0.0
-2018-11-07,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-21,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,2,0.0
-2019-01-25,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-04-02,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,4,0.0
-2019-05-17,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-01-22,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-02-13,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-04-28,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-12-07,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,2,0.0
-2019-03-08,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-03-07,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-03-03,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2018-10-25,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,4,0.0
-2019-02-08,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-15,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-11-20,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-03-04,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-12-10,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2018-11-09,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,1,0.0
-2018-10-23,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-02-20,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-01-04,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-19,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-04-11,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,3,0.0
-2019-05-20,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2018-12-04,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-03-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,2,0.0
-2019-03-28,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,2,0.0
-2019-02-10,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-01-23,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,8,0.0
-2018-11-21,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-12-11,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-03-01,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,4,0.0
-2018-12-12,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,2,0.0
-2018-12-03,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,2,0.0
-2018-09-20,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-05-13,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-03-21,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-03-20,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-03-18,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-02-06,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,1,0.0
-2019-02-14,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,5,0.0
-2018-12-08,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,1,0.0
-2018-10-10,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2018-10-16,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,2,0.0
-2018-10-28,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,3,0.0
-2018-12-05,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,24,0.0
-2019-04-07,150175881,349886458,USD,iOS,Tablet,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-03-25,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,3,0.0
-2019-01-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,3,0.0
-2019-04-30,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,2,0.0
-2019-05-13,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,3,0.0
-2019-02-06,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,3,0.0
-2019-03-18,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-01-07,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-10-19,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,4,0.0
-2019-01-03,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,5,0.0
-2019-04-23,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-05-16,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-21,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-03-21,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2018-10-11,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-03-07,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,3,0.0
-2019-05-10,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,3,0.0
-2019-01-26,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-12-05,150175881,349886458,USD,Windows,Computer,AOL search,Search,Phrase,Phrase,AOL search - Top,0,1,0.0
-2018-10-17,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2018-09-17,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-03-21,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-04-05,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-04-19,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-12-26,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,1,0.0
-2019-02-24,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-03,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-04-08,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-01-22,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,4,0.0
-2019-01-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-06,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-17,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-03-30,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2018-11-30,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,2,0.0
-2018-12-05,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,25,0.0
-2019-02-19,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,5,0.0
-2019-04-03,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-17,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,5,0.0
-2019-04-24,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,3,0.0
-2019-04-25,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,3,0.0
-2018-10-27,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2018-12-21,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,3,0.0
-2019-04-25,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-17,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-01-23,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-15,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,3,0.0
-2018-10-08,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,3,0.0
-2019-04-26,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2018-11-09,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2018-11-02,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2018-12-17,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-02-05,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-10-05,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-05-23,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2018-12-15,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-03-11,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,3,0.0
-2018-12-10,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-02-28,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,5,0.0
-2018-12-14,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-01-26,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-04-01,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,4,0.0
-2018-12-04,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-02-22,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-03-11,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2018-10-24,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-03-13,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,4,0.0
-2019-03-08,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-02-25,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,4,0.0
-2019-02-14,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-03-26,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-01,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2018-12-23,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,1,0.0
-2018-12-24,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2018-12-14,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,2,0.0
-2018-10-17,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,3,0.0
-2018-11-12,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-03-27,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-16,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-03-19,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-16,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-22,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-03-22,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-03,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,5,0.0
-2019-03-06,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,1,0.0
-2019-03-13,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,1,0.0
-2018-11-01,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-12-17,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-04-05,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,1,0.0
-2019-05-27,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2018-12-05,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-02-18,150175881,349886458,USD,Android,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-05-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,2,0.0
-2018-12-05,150175881,349886458,USD,Unknown,Computer,AOL search,Search,Phrase,Phrase,AOL search - Top,0,5,0.0
-2019-05-10,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2018-12-11,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-10-02,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,2,0.0
-2018-12-07,150175881,349886458,USD,Windows,Computer,AOL search,Search,Phrase,Phrase,AOL search - Top,0,2,0.0
-2019-04-04,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,3,0.0
-2019-05-17,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-04-01,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-05-08,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-04-08,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,2,0.0
-2018-10-02,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-09-25,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,2,0.0
-2018-10-07,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-20,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-04-08,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-05-21,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,5,0.0
-2019-04-16,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,3,0.0
-2018-12-18,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-11-22,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-03-11,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-02-22,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2018-12-22,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,2,0.0
-2019-04-09,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-04-25,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2018-12-14,150175881,349886458,USD,iOS,Tablet,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2018-10-15,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2018-10-10,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2019-03-19,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,1,0.0
-2018-11-05,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2018-12-06,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,1,0.0
-2019-02-11,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,0,2,0.0
-2018-11-26,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-05-02,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,4,0.0
-2019-04-29,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,4,0.0
-2019-02-12,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,4,0.0
-2018-10-18,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,3,0.0
-2019-03-12,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,0,3,0.0
-2019-03-14,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-02-25,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,3,0.0
-2019-02-25,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-03-22,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,3,0.0
-2019-02-13,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,2,0.0
-2019-04-29,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,0,1,0.0
-2019-02-06,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,1,5,0.18
-2019-04-15,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,5,0.09
-2018-10-26,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,5,2.49
-2019-03-26,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,1,5,0.63
-2018-10-22,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,1,4,0.27
-2019-03-13,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,4,0.92
-2019-03-17,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,1,4,0.33
-2019-04-26,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,4,1.0
-2019-01-08,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,1,4,1.06
-2019-05-02,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,2,5,2.73
-2019-03-20,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,2,5,2.21
-2018-11-01,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,2,0.05
-2019-04-02,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,1,2,1.65
-2019-03-23,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,2,1.64
-2019-02-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,2,4,0.87
-2019-05-24,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,2,0.81
-2019-04-18,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,2,2.34
-2018-09-26,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,2,0.95
-2019-05-08,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,1,2,0.55
-2019-03-29,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,2,0.48
-2019-02-06,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,2,2.25
-2019-04-27,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,2,2.02
-2019-04-05,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,2,1.07
-2019-05-06,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,2,0.83
-2019-05-17,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,2,4,2.6
-2019-04-09,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,2,0.53
-2019-03-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,2,1.15
-2019-03-19,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,1,2,0.54
-2019-04-03,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,2,4,2.25
-2019-04-01,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,2,2.61
-2018-12-12,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,1,2,0.05
-2019-05-28,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,2,1.0
-2019-02-15,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,2,2.44
-2019-05-01,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,2,1.0
-2019-02-05,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,2,4,2.88
-2019-05-01,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,1,2,0.3
-2018-09-21,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,4,8,7.51
-2018-12-19,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,2,1.36
-2018-11-27,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,2,1.19
-2019-05-02,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,2,1.0
-2019-04-15,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,2,2.08
-2019-05-08,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,2,1.0
-2018-11-29,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,2,4,3.03
-2019-05-12,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,2,1.0
-2019-05-06,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,1,1,0.3
-2018-12-04,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,1,1.78
-2018-12-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,1,2.33
-2019-02-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,1,2.28
-2019-01-22,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,1,1,0.29
-2019-03-07,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,1,1.0
-2018-12-26,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,1,2.82
-2019-02-17,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,1,0.05
-2019-05-09,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,1,0.54
-2018-10-12,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,2,2,0.96
-2019-01-10,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,1,1,0.04
-2018-11-26,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,1,1.12
-2019-03-29,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,1,1,1.0
-2018-11-14,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,1,2.28
-2018-09-20,150175881,349886458,USD,Android,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,1,0.85
-2019-05-15,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,1,1.09
-2019-01-28,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,1,5.39
-2019-05-02,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,1,0.9
-2019-02-07,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,1,1.61
-2019-03-19,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,1,1,1.0
-2019-03-14,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,1,0.77
-2018-11-07,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,1,1.06
-2018-10-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,1,2.79
-2019-05-07,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,1,0.69
-2019-05-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,3,1.49
-2019-01-24,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,1,3,0.05
-2019-02-12,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,1,3,0.06
-2019-04-05,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,2,6,1.97
-2018-10-07,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,3,3.07
-2019-02-27,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,3,1.97
-2019-05-20,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,1,3,0.05
-2018-10-08,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,3,1.0
-2019-02-15,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,1,3,2.17
-2019-03-11,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,3,2.83
-2018-12-04,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,1,3,0.04
-2019-03-28,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,1,3,1.0
-2019-04-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,3,1.0
-2018-11-28,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,3,1.22
-2018-12-05,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,61,1.32
-2019-02-26,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,2,3,0.72
-2019-05-23,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,2,3,2.36
-2019-05-14,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,3,7,2.19
-2018-11-22,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,1,9,0.28
-2018-12-06,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,9,1.27
-2019-03-01,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,13,1.48
-2018-10-09,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,1,6,1.16
+date,account_id,campaign_id,currency_code,device_os,device_type,network,ad_distribution,bid_match_type,delivered_match_type,top_vs_other,budget_association_status,clicks,impressions,spend
+2019-05-22,150175881,359751135,USD,Unknown,Unknown,Bing and Yahoo! search,Search,Unknown,Unknown,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-30,150175881,359751135,USD,Unknown,Unknown,Bing and Yahoo! search,Search,Unknown,Unknown,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-23,150175881,359751135,USD,Unknown,Unknown,Bing and Yahoo! search,Search,Unknown,Unknown,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-06-27,150175881,359751135,USD,Unknown,Unknown,Bing and Yahoo! search,Search,Unknown,Unknown,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-15,150175881,359751135,USD,Unknown,Unknown,Bing and Yahoo! search,Search,Unknown,Unknown,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-09,150175881,359751135,USD,Unknown,Unknown,Bing and Yahoo! search,Search,Unknown,Unknown,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-02,150175881,359751135,USD,Unknown,Unknown,Bing and Yahoo! search,Search,Unknown,Unknown,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-20,150175881,359751135,USD,Unknown,Unknown,Bing and Yahoo! search,Search,Unknown,Unknown,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-26,150175881,359751135,USD,Unknown,Unknown,Bing and Yahoo! search,Search,Unknown,Unknown,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-22,150175881,359751135,USD,Unknown,Unknown,Bing and Yahoo! search,Search,Unknown,Unknown,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-25,150175881,359751135,USD,Unknown,Unknown,Bing and Yahoo! search,Search,Unknown,Unknown,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-06-26,150175881,359751135,USD,Unknown,Unknown,Bing and Yahoo! search,Search,Unknown,Unknown,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-06-10,150175881,359751135,USD,Unknown,Unknown,Bing and Yahoo! search,Search,Unknown,Unknown,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-15,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,0,0.0
+2019-04-23,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-06,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-08,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,0,0.0
+2019-05-18,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-05-18,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-28,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-01-23,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-05-27,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-05-05,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-27,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2019-05-16,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-04-28,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-04-21,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-15,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-20,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,0,0.0
+2019-04-14,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-14,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,0,0.0
+2019-04-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-01-23,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-25,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-12,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,0,0.0
+2019-05-10,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-20,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2019-04-23,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-28,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-06,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-03,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2019-04-07,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,0,0.0
+2019-04-17,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2019-05-21,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-27,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-05-25,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-02,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2019-04-25,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-03,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,0,0.0
+2019-05-20,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-05-21,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-25,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-04-07,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-24,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-15,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-10,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-11,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2019-04-29,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-19,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2019-04-28,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-27,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-13,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2019-04-30,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-30,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-12,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-05-20,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-04-29,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-05-18,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-05-28,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2019-04-11,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-05-26,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-22,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-24,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-06,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-20,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-24,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-08,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-05-02,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2019-05-11,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-05-02,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-19,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-09,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-04-12,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-29,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-19,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2019-04-16,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-05-15,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-04-21,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-05,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-12,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2019-05-25,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2019-04-20,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-26,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-15,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-05-14,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-05-14,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-04-26,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,0,0.0
+2019-05-12,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-19,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-25,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-22,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,0,0.0
+2019-04-19,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,0,0.0
+2019-04-24,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-08,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-05-18,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-12,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-16,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,0,0.0
+2019-04-28,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,0,0.0
+2019-04-27,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-04-17,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-05-22,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-24,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2019-05-27,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-05-02,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-05-11,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-17,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-07,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2019-04-13,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-10,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-24,150175881,359751135,USD,Android,Tablet,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-07,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,0,0.0
+2019-05-27,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-29,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-05-16,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-16,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-27,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-10,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-05-03,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-23,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-24,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-04-27,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-21,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-22,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-27,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-05,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-03,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-05-02,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-25,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,0,0.0
+2019-05-27,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2019-05-17,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-21,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,0,0.0
+2018-11-28,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-29,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-28,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-25,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-11,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2018-12-13,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-08,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2019-05-19,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,0,0.0
+2019-05-28,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-05-04,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2019-04-13,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2019-04-19,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-20,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-09,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2019-04-07,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-26,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-05,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-08,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-24,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-25,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2019-04-06,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-19,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-09,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2019-05-02,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,0,0.0
+2019-04-30,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-10,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2019-04-26,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-04-20,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-04,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2019-05-08,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-19,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-10,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-05-28,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-24,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-05,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2019-05-08,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2019-05-03,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-05-11,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-18,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-04-12,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2019-04-08,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,0,0.0
+2019-04-11,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,0,0.0
+2019-05-04,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,0,0.0
+2019-04-10,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-22,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-17,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-13,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-04-18,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,0,0.0
+2019-05-11,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,0,0.0
+2019-05-13,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-16,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-05,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,0,0.0
+2019-05-19,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-13,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,0,0.0
+2019-04-07,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-20,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-21,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2019-04-12,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-26,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-05-09,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-01,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-21,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-01-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-06,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-01,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-04,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-05,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,4,0.0
+2019-05-15,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-20,150175881,359751135,USD,iOS,Tablet,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-19,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-08,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-04-23,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-08,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-04-18,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,3,0.0
+2019-04-19,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-18,150175881,359751135,USD,Android,Tablet,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-09,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,3,0.0
+2019-04-21,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-02-19,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-02-20,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-20,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-05,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-01,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-17,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-22,150175881,359751135,USD,iOS,Tablet,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-23,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-04-19,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-07,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-22,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-01-23,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-07,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,16,0.0
+2019-04-30,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-21,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,4,0.0
+2019-04-26,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Other,Current,0,2,0.0
+2019-05-20,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Other,Current,0,2,0.0
+2019-05-07,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,4,0.0
+2019-05-08,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-27,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-17,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-04-09,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-05-24,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,3,0.0
+2019-05-26,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,4,0.0
+2019-03-26,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-01,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-29,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-12,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-05-21,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-05-04,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-13,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-23,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-20,150175881,359751135,USD,iOS,Tablet,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Other,Current,0,3,0.0
+2019-04-15,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,15,0.0
+2019-04-20,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,3,0.0
+2019-04-24,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-05,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-30,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,7,0.0
+2019-05-06,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-04-30,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,3,0.0
+2019-05-14,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,5,0.0
+2019-04-25,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-24,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,3,0.0
+2019-04-12,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-20,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,5,0.0
+2019-04-25,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,5,0.0
+2019-03-04,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-15,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,3,0.0
+2019-05-28,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-05-17,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-04-11,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,4,0.0
+2019-04-15,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-04-21,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,2,0.0
+2018-10-24,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-07,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-14,150175881,359751135,USD,Android,Tablet,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-12,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-04,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2019-05-17,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,3,0.0
+2019-05-05,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,16,0.0
+2019-04-17,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-18,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,3,0.0
+2019-04-23,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,25,0.0
+2019-04-24,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,23,0.0
+2019-03-12,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-04,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-03,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-03,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,6,0.0
+2019-05-02,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-14,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,2,0.0
+2019-04-26,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-26,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-04-15,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-23,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-04-21,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-10,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,13,0.0
+2018-10-23,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-08,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-01,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-14,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,4,0.0
+2019-05-21,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-21,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,4,0.0
+2019-05-05,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,4,0.0
+2019-05-28,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,11,0.0
+2019-04-23,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,2,0.0
+2019-04-15,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,4,0.0
+2019-05-21,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-01-22,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-30,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-28,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-04,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-02,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,5,0.0
+2019-04-30,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,3,0.0
+2019-04-30,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-08,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-04-23,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-12,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-04-16,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,4,0.0
+2019-05-26,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-22,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,4,0.0
+2019-05-22,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,4,0.0
+2019-04-29,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Other,Current,0,1,0.0
+2019-03-22,150175881,349886458,USD,iOS,Tablet,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-27,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-30,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Other,Current,0,1,0.0
+2019-05-04,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Other,Current,0,3,0.0
+2019-05-10,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2019-04-29,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,3,0.0
+2019-05-20,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,2,0.0
+2019-04-29,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-27,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-01,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,17,0.0
+2019-04-11,150175881,359751135,USD,iOS,Tablet,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,5,0.0
+2019-04-17,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,4,0.0
+2019-04-22,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-05,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-05-19,150175881,359751135,USD,Android,Tablet,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-05-08,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,4,0.0
+2019-05-15,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-05,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-30,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-04,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,5,0.0
+2019-04-09,150175881,359751135,USD,iOS,Tablet,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-23,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,4,0.0
+2019-05-22,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,6,0.0
+2019-04-10,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-01-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,Current,0,3,0.0
+2019-05-09,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-10,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,4,0.0
+2019-05-27,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,10,0.0
+2019-05-01,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-17,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-22,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-18,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-04-07,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,6,0.0
+2019-04-15,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,3,0.0
+2019-05-26,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2018-10-19,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-08,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-02-25,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-05-15,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-05-13,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,11,0.0
+2019-05-17,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-18,150175881,359751135,USD,iOS,Tablet,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-08,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Other,Current,0,1,0.0
+2019-05-13,150175881,359751135,USD,iOS,Tablet,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-15,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,4,0.0
+2019-05-11,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,7,0.0
+2019-04-24,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-16,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,4,0.0
+2019-04-22,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-04-05,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Other,Current,0,1,0.0
+2019-05-28,150175881,359751135,USD,Windows,Computer,Audience,Audience,Broad,Broad,Audience network,Current,0,1,0.0
+2019-05-18,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-19,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,11,0.0
+2019-04-23,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-09,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-24,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-09,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,13,0.0
+2019-04-08,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,1,0.0
+2018-11-12,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-03-06,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-06,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-12-05,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-16,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-17,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Other,Current,0,1,0.0
+2019-05-10,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-08,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,3,0.0
+2019-05-08,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-27,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Other,Current,0,2,0.0
+2019-05-21,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,3,0.0
+2019-04-26,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,3,0.0
+2019-04-08,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-12,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,4,0.0
+2019-04-10,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,7,0.0
+2019-05-26,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,5,0.0
+2019-04-25,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-17,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-04-15,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,4,0.0
+2019-04-22,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,11,0.0
+2019-05-27,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,3,0.0
+2019-05-25,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-26,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2019-05-05,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-05-28,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,3,0.0
+2019-04-25,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-08,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,12,0.0
+2019-05-17,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-29,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,8,0.0
+2019-05-14,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-15,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-14,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,5,0.0
+2019-04-07,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,3,0.0
+2019-04-09,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-04-18,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2019-02-06,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-02,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,3,0.0
+2019-05-13,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-11,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-15,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-01,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-05-08,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-05-17,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-16,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,19,0.0
+2019-04-15,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-10,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-04-17,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-16,150175881,359751135,USD,Android,Tablet,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-22,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,6,0.0
+2019-04-17,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,6,0.0
+2019-05-17,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-17,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-14,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-17,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,Current,0,2,0.0
+2019-05-01,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,6,0.0
+2019-04-09,150175881,359751135,USD,Android,Tablet,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-24,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,4,0.0
+2019-04-23,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,Current,0,2,0.0
+2019-04-27,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-25,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-08,150175881,359751135,USD,Windows,Computer,AOL search,Search,Broad,Broad,AOL search - Top,Current,0,3,0.0
+2019-05-14,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-13,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,5,0.0
+2019-04-12,150175881,359751135,USD,Android,Tablet,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-10,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-17,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Other,Current,0,1,0.0
+2019-04-18,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,15,0.0
+2019-04-25,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,7,0.0
+2018-11-02,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-03-27,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-30,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-04-27,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-04,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,6,0.0
+2019-05-18,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,14,0.0
+2019-05-14,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,5,0.0
+2019-05-07,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,3,0.0
+2019-05-07,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-05-26,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Other,Current,0,1,0.0
+2019-04-20,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-05-24,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-23,150175881,359751135,USD,Android,Smartphone,Audience,Audience,Broad,Broad,Audience network,Current,0,1,0.0
+2019-04-10,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-05-10,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-20,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-07,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,5,0.0
+2019-04-29,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,6,0.0
+2019-05-17,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,21,0.0
+2019-04-27,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-04-21,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-04-21,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-04-15,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-26,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,5,0.0
+2019-04-08,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2019-04-25,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2019-04-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-01-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-05-08,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-13,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-05-05,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,8,0.0
+2018-10-16,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-05,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-18,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-05-22,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,4,0.0
+2019-04-08,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,3,0.0
+2019-04-17,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-04-21,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,6,0.0
+2019-04-18,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,6,0.0
+2019-05-22,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,Current,0,1,0.0
+2018-09-20,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-04,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-03,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-07,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-02,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-05-08,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,20,0.0
+2019-05-03,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,24,0.0
+2019-05-23,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-04-17,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,15,0.0
+2019-04-20,150175881,359751135,USD,iOS,Tablet,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-25,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,4,0.0
+2019-04-16,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,6,0.0
+2019-05-23,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,2,0.0
+2018-10-23,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2018-10-25,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-13,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-26,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-03,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,8,0.0
+2019-04-09,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,3,0.0
+2019-05-26,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-23,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,6,0.0
+2018-11-13,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-05,150175881,359751135,USD,iOS,Tablet,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-12,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-05-01,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-05-16,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,3,0.0
+2019-04-19,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-24,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,6,0.0
+2019-04-25,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,5,0.0
+2019-04-16,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,16,0.0
+2018-11-22,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,2,0.0
+2018-12-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-10-05,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-20,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-07,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,28,0.0
+2019-05-27,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-17,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,11,0.0
+2019-05-23,150175881,359751135,USD,iOS,Tablet,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-03-12,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2018-10-05,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-26,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-16,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,7,0.0
+2019-04-29,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,18,0.0
+2019-04-09,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-25,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,2,0.0
+2018-12-18,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-01-25,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-17,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,10,0.0
+2019-05-01,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-19,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-04,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-04-12,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-04-08,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-11,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,3,0.0
+2019-05-23,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-15,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-16,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,Current,0,4,0.0
+2019-04-24,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,6,0.0
+2019-04-19,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,12,0.0
+2018-11-20,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-02-04,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-06,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-03,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,3,0.0
+2019-05-07,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-05-25,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-13,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-17,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,10,0.0
+2019-05-04,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,5,0.0
+2019-05-23,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,3,0.0
+2019-04-11,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-14,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,2,0.0
+2019-05-22,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,8,0.0
+2019-04-25,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,3,0.0
+2019-05-16,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,6,0.0
+2019-05-13,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-15,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-03,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-21,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-10,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-04-20,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-23,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,7,0.0
+2019-05-24,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,27,0.0
+2019-05-23,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,18,0.0
+2019-04-25,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,Current,0,2,0.0
+2019-03-31,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-29,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,4,0.0
+2019-05-05,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-27,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-01,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-10-09,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-26,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,7,0.0
+2019-04-28,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-06,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,Current,0,3,0.0
+2019-04-11,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,4,0.0
+2019-04-21,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,27,0.0
+2019-04-19,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,3,0.0
+2019-04-09,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-17,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,25,0.0
+2019-05-15,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-19,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,19,0.0
+2019-04-11,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-11,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,4,0.0
+2019-04-17,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,2,0.0
+2019-04-24,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,7,0.0
+2019-03-14,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-14,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Other,Current,0,1,0.0
+2019-05-13,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-09,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,2,0.0
+2019-04-20,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-09,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-04-23,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-10-24,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-16,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-05-01,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-21,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Other,Current,0,1,0.0
+2019-05-06,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-17,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-05-08,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-09,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,6,0.0
+2019-05-08,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,47,0.0
+2019-04-16,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,5,0.0
+2019-04-14,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-10,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-19,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-09,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-21,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-27,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-04-30,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,28,0.0
+2019-05-10,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-16,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,7,0.0
+2019-05-18,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,4,0.0
+2019-05-18,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,6,0.0
+2019-05-14,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,3,0.0
+2019-05-12,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,5,0.0
+2019-05-27,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-24,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-26,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-04-01,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-18,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-28,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-01,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-23,150175881,359751135,USD,iOS,Tablet,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Other,Current,0,1,0.0
+2019-02-15,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-07,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-19,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-20,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,10,0.0
+2019-05-13,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-01,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,2,0.0
+2019-05-02,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2019-05-27,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,8,0.0
+2019-05-22,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Other,Current,0,1,0.0
+2019-04-18,150175881,359751135,USD,iOS,Tablet,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Other,Current,0,1,0.0
+2019-04-24,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2019-05-24,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,2,0.0
+2019-04-19,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,2,0.0
+2019-04-15,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,2,0.0
+2019-05-20,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-06,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-10-16,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-19,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,3,0.0
+2019-05-13,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-08,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,3,0.0
+2019-04-28,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-05-06,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-07,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,4,0.0
+2019-05-01,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,3,0.0
+2019-04-29,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,4,0.0
+2019-04-22,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-09,150175881,359751135,USD,Android,Tablet,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Other,Current,0,1,0.0
+2019-04-08,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-23,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-23,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-25,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,46,0.0
+2019-05-23,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,4,0.0
+2019-05-27,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-05,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-02-04,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-22,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-29,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-14,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-25,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-28,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-01,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-28,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,4,0.0
+2019-04-24,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,Current,0,3,0.0
+2019-04-22,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,2,0.0
+2019-05-06,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,3,0.0
+2019-05-18,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-09,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-10,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-16,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,16,0.0
+2019-04-15,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2019-04-19,150175881,359751135,USD,iOS,Tablet,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Other,Current,0,1,0.0
+2019-04-17,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,3,0.0
+2019-05-23,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-22,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,4,0.0
+2019-05-20,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,2,0.0
+2019-04-29,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-07,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-05,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,10,0.0
+2019-04-29,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,3,0.0
+2019-05-10,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-14,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-23,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-22,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-23,150175881,359751135,USD,Android,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-18,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-23,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-03-29,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-02-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-05-14,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Other,Current,0,1,0.0
+2018-10-12,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-08,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,3,0.0
+2019-05-06,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-05,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-16,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,20,0.0
+2019-04-20,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-23,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,2,0.0
+2019-04-24,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,2,0.0
+2019-03-14,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-23,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-04,150175881,359751135,USD,Android,Tablet,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Other,Current,0,1,0.0
+2019-04-27,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-05-03,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,3,0.0
+2019-05-17,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,3,0.0
+2019-05-10,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-22,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-22,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,4,0.0
+2019-05-22,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-15,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-04-20,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,20,0.0
+2019-02-04,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-10,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-26,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-06,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,4,0.0
+2019-04-30,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,2,0.0
+2019-04-21,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-23,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,4,0.0
+2019-05-09,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,4,0.0
+2019-04-30,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-04-29,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,14,0.0
+2019-05-07,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-18,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-05,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,12,0.0
+2019-05-17,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,5,0.0
+2019-04-11,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,4,0.0
+2019-04-14,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,4,0.0
+2019-04-22,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,4,0.0
+2019-05-23,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-22,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,26,0.0
+2018-10-28,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-03-12,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-04-25,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-14,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-20,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-05-16,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-12,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-04-11,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,3,0.0
+2019-04-10,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-24,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,3,0.0
+2019-05-26,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-20,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-04-17,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,6,0.0
+2019-03-08,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-28,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-02,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,11,0.0
+2019-05-19,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-05-19,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-27,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-07,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-04,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-26,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-01,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-05-07,150175881,359751135,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-16,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,8,0.0
+2019-04-19,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-04-11,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,6,0.0
+2019-04-24,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,34,0.0
+2019-05-02,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2019-01-25,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-20,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,14,0.0
+2019-05-14,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-07,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,4,0.0
+2019-05-06,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,3,0.0
+2019-05-09,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-18,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,25,0.0
+2019-04-13,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,0,4,0.0
+2019-04-13,150175881,359751135,USD,Windows,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,2,0.0
+2019-04-14,150175881,359751135,USD,iOS,Tablet,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-22,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,0,15,0.0
+2019-05-08,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,1,20,7.0
+2019-05-22,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,2,40,17.82
+2019-04-18,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,1,20,9.7
+2019-05-02,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,1,20,5.36
+2019-04-23,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,3,48,5.6
+2019-05-11,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,1,16,5.09
+2019-05-25,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,1,10,5.92
+2019-05-03,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,1,10,6.23
+2019-05-12,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,1,8,1.91
+2019-05-28,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,1,8,4.91
+2019-05-25,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,1,8,7.2
+2019-05-14,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,4,32,20.47
+2019-05-23,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,3,20,17.01
+2019-05-15,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,3,15,25.8
+2019-04-09,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Exact,Syndicated search partners - Top,Current,1,4,0.51
+2019-05-16,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,1,4,0.86
+2019-05-06,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Other,Current,1,4,9.31
+2019-05-24,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,1,4,6.04
+2019-05-16,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,1,2,8.82
+2018-10-09,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,1,1,5.6
+2018-09-19,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,1,1,0.5
+2019-04-28,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,1,1,5.19
+2018-10-05,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,1,1,1.08
+2019-04-14,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,1,1,2.93
+2019-03-29,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Exact,Bing and Yahoo! search - Top,Current,2,2,3.6
+2019-04-23,150175881,359751135,USD,Unknown,Computer,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,1,1,7.85
+2019-05-14,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,1,1,1.65
+2019-04-12,150175881,359751135,USD,Android,Tablet,Syndicated search partners,Search,Broad,Phrase,Syndicated search partners - Top,Current,1,1,8.12
+2019-05-24,150175881,359751135,USD,Android,Tablet,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Other,Current,1,1,1.57
+2019-05-14,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,1,47,4.0
+2019-05-12,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,1,42,5.02
+2019-05-09,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,2,47,1.52
+2019-05-02,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,1,21,9.24
+2019-05-25,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,1,3,5.84
+2019-05-21,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,2,6,11.49
+2019-05-06,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,1,7,4.12
+2019-04-15,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,2,24,14.48
+2019-04-30,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,1,12,1.48
+2019-05-20,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,1,22,5.64
+2019-04-27,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,5,180,6.18
+2019-04-19,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,1,18,3.62
+2019-04-26,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,3,54,3.86
+2019-05-12,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,3,22,11.28
+2019-05-06,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,1,46,0.7
+2019-05-06,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,1,23,0.65
+2019-04-25,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,1,23,6.5
+2019-04-25,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,5,170,7.53
+2019-05-17,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,2,41,17.44
+2019-05-10,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,2,17,1.53
+2019-05-13,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,4,38,25.56
+2019-05-01,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,2,19,10.29
+2019-05-10,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,1,28,4.76
+2019-04-30,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,1,28,5.95
+2019-05-09,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,1,28,2.65
+2019-05-20,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,1,28,5.69
+2019-05-01,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,1,28,6.57
+2019-05-13,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,2,28,7.13
+2019-05-14,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,2,74,9.83
+2019-04-29,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,4,116,6.42
+2019-05-10,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,1,29,6.73
+2019-04-27,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,2,29,1.12
+2019-04-22,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,1,54,1.5
+2019-04-21,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,1,48,2.34
+2019-04-23,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,6,195,16.27
+2019-04-20,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,5,39,16.69
+2019-05-06,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,1,24,9.91
+2019-04-26,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,11,203,15.18
+2019-05-11,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,1,15,5.03
+2019-04-26,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,1,15,7.94
+2019-04-18,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,1,9,4.06
+2019-05-24,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,1,9,4.1
+2019-05-07,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,2,9,1.62
+2019-04-19,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,2,26,8.6
+2019-04-15,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,1,13,5.96
+2019-05-09,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,2,26,6.19
+2019-05-19,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,1,13,4.81
+2019-05-21,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,2,26,13.68
+2019-05-13,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,2,77,6.73
+2019-04-12,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,1,6,9.72
+2019-04-10,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,1,6,6.95
+2019-05-03,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,1,6,7.56
+2019-05-10,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,1,6,8.7
+2019-05-13,150175881,359751135,USD,Unknown,Computer,Bing and Yahoo! search,Search,Broad,Broad,Bing and Yahoo! search - Top,Current,1,6,8.62
+2019-05-02,150175881,359751135,USD,Windows,Computer,Bing and Yahoo! search,Search,Broad,Phrase,Bing and Yahoo! search - Top,Current,1,6,9.73
+2019-04-28,150175881,359751135,USD,iOS,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,3,71,1.21
+2019-04-28,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,8,189,6.79
+2019-04-24,150175881,359751135,USD,Android,Smartphone,Syndicated search partners,Search,Broad,Broad,Syndicated search partners - Top,Current,1,178,3.17
+2018-11-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-27,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-01-03,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-01-07,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-09,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-11-21,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-07,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-21,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-09,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-03,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-10-28,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,0,0.0
+2019-03-12,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-13,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-27,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-11-26,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-18,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-20,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-09,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-26,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-10-13,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,0,0.0
+2018-12-02,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-01,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-14,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-02,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-03,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-10-07,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-11-16,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-01,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-16,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,0,0.0
+2019-05-15,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-05-23,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-14,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-04-24,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-16,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-09,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,0,0.0
+2019-03-22,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-09-17,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,0,0.0
+2019-05-26,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-18,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-01-21,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,0,0.0
+2019-04-22,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-19,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-11-11,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-08,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-14,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-13,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-09-17,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,0,0.0
+2019-02-07,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,0,0.0
+2018-12-06,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-11-22,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-17,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-04-24,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-01-10,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-04-27,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,0,0.0
+2019-03-19,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-17,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,0,0.0
+2019-02-14,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-23,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-01-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-03,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-23,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2018-12-15,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-10-06,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-05-27,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-01-06,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-09-25,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-18,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-26,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-10,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-18,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-09,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-18,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-02-24,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-11-29,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-20,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-10,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-11,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-03-04,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-11-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-03,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-29,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-21,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-03-02,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-13,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-03-14,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-10-03,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-30,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,0,0.0
+2018-12-22,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,0,0.0
+2019-03-22,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-03,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,0,0.0
+2018-11-11,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-05-09,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-04-16,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-29,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-12,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-11-10,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-13,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-24,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,0,0.0
+2018-10-07,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-03-23,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-01-26,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-25,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-23,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-30,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-18,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2018-12-03,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-11,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-09,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-08,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-01-20,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-16,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-09-24,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-22,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-06,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-10,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-03-25,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-04-07,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-30,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-22,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-13,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,0,0.0
+2019-02-04,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-17,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,0,0.0
+2019-03-17,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-10,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-27,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-11-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-05-09,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-04-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-21,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-03,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,0,0.0
+2018-12-02,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-10-17,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-01,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-01,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-14,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2018-12-22,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,0,0.0
+2019-04-03,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-01-09,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-05-15,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-10-06,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,0,0.0
+2018-11-13,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,0,0.0
+2019-03-05,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-10-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-03-24,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-04-19,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-02-18,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-01-08,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-01-05,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-10-18,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-04,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,0,0.0
+2018-11-10,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-07,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-01-05,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-09,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-11,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-14,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-01-03,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-01-02,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-08,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-11-30,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-02,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,0,0.0
+2018-11-26,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,0,0.0
+2019-04-28,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-01-27,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-18,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-02-16,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-18,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-14,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-01-10,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2018-12-11,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-01,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-06,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-05-12,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-12,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-26,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-24,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-14,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-11-27,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-05-16,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-03-25,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-07,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-12,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-11-09,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-12-13,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-17,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-07,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-29,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-12-20,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-02-20,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-04-19,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2018-11-01,150175881,349886458,USD,iOS,Tablet,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2018-12-20,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,2,0.0
+2018-09-20,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,2,0.0
+2018-11-27,150175881,349886458,USD,Android,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-07,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-03-29,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-02-01,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,2,0.0
+2018-10-12,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-01-10,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-12-11,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-09-25,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-09-21,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-02-25,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-02-17,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-25,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-15,150175881,349886458,USD,iOS,Tablet,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-22,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-18,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-05,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,4,0.0
+2019-05-26,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,3,0.0
+2019-01-10,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,5,0.0
+2019-03-11,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,5,0.0
+2018-11-05,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,4,0.0
+2018-09-18,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,2,0.0
+2018-09-24,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,1,0.0
+2018-09-18,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-03-19,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-04-07,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-08,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-03-15,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-02-27,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2018-10-22,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2018-12-20,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2018-09-23,150175881,349886458,USD,Android,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-06,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-20,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-01-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-03-10,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2018-11-21,150175881,349886458,USD,Android,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-03-01,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2018-10-23,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2018-11-08,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-03-15,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-10-02,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-25,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-01-24,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,5,0.0
+2019-02-19,150175881,349886458,USD,iOS,Tablet,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-03-23,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-01,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-03-22,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-01-08,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,5,0.0
+2019-04-15,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-03-14,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2018-10-04,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-01-25,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-18,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-04-23,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2019-02-22,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2018-12-21,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,2,0.0
+2019-05-13,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-19,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-10-10,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2018-12-11,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-02-14,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-27,150175881,349886458,USD,iOS,Tablet,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-03-27,150175881,349886458,USD,Android,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-20,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2019-04-29,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-11-04,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-01-22,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-12,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-04-18,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-10-18,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,2,0.0
+2018-10-09,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-02-06,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-10-09,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-03-02,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-02-08,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2019-02-14,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,2,0.0
+2018-11-22,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-15,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-09-26,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-09-24,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-04,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,2,0.0
+2019-03-29,150175881,349886458,USD,Android,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-01-07,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-01-28,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-01-03,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2019-03-20,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-08,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-02-26,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-03-04,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,5,0.0
+2018-12-13,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2018-12-01,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-02-25,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,6,0.0
+2019-05-10,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2019-02-13,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-01-28,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-02-10,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-17,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-10-16,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2019-03-02,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2018-10-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-09-21,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-03,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,5,0.0
+2019-02-11,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-11-05,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,4,0.0
+2019-04-10,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-12-14,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-04-24,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,2,0.0
+2018-11-28,150175881,349886462,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-10-19,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-11-19,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-10-22,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,2,0.0
+2018-10-28,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2018-10-02,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,1,0.0
+2018-12-25,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-24,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2019-04-24,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-06,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,5,0.0
+2019-02-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,2,0.0
+2018-10-15,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-02-05,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-09-24,150175881,349886458,USD,Android,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-10-16,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-03-18,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,2,0.0
+2018-12-14,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-03-26,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-08,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-08,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2019-04-30,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-03,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-20,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-07,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,2,0.0
+2018-10-09,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2019-02-19,150175881,349886462,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-03-09,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-10-23,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-11-13,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-14,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,6,0.0
+2019-04-17,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-01,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-08,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-02-15,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-02-12,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-21,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2019-02-11,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-15,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2019-02-23,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-10-20,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-10-23,150175881,349886458,USD,Android,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-11-14,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-03-05,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-03-18,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2018-12-24,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-16,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-27,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-23,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-12-05,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,2,0.0
+2018-10-09,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-10-17,150175881,349886458,USD,iOS,Tablet,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2018-10-17,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,3,0.0
+2018-12-03,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2018-11-14,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-02-24,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-09,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-15,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2018-10-07,150175881,349886458,USD,iOS,Tablet,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-01-25,150175881,349886458,USD,Android,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-03-29,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-28,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,3,0.0
+2019-03-17,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,4,0.0
+2018-10-30,150175881,349886458,USD,iOS,Tablet,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-07,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-09-19,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-27,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,4,0.0
+2019-04-11,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-26,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,2,0.0
+2019-03-20,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,3,0.0
+2019-05-02,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-30,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2018-10-11,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-11-15,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-02-26,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-03-20,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-05-23,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2018-12-06,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-02-19,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-01-27,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2018-12-03,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2018-10-26,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2018-11-22,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,4,0.0
+2018-10-03,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-04-03,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-02-23,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-31,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-06,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-02-13,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-20,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-20,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,4,0.0
+2019-03-04,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-10-19,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-02-28,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-03-05,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-03-19,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-03-19,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-24,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,3,0.0
+2019-03-29,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2018-10-16,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2018-11-22,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2018-10-24,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-17,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-02-01,150175881,349886458,USD,iOS,Tablet,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-02,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,3,0.0
+2018-10-17,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,4,0.0
+2018-11-13,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-11-07,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2018-11-07,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-13,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-09-25,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,1,0.0
+2018-09-24,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-01-03,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,4,0.0
+2019-04-10,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-04-25,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-01-02,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-09,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-14,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2018-12-05,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,6,0.0
+2018-10-15,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2018-09-24,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,2,0.0
+2019-05-02,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,7,0.0
+2019-01-03,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-11-02,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-26,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-29,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-02-13,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-02-20,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-01-25,150175881,349886458,USD,iOS,Tablet,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-02-11,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-02-18,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-22,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-10-11,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-10-10,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,4,0.0
+2018-10-17,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2018-09-17,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-12-27,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-02-07,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-06,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,3,0.0
+2018-10-22,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,1,0.0
+2018-09-20,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,1,0.0
+2018-12-05,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,1,0.0
+2018-12-11,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,1,0.0
+2018-10-26,150175881,349886458,USD,Windows,Computer,AOL search,Search,Exact,Exact,AOL search - Top,Current,0,1,0.0
+2019-02-22,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-10-29,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-03-27,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-14,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-24,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-04-16,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-02,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-08,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-02-06,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-04-04,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2019-02-21,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-03-10,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-10-30,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-02-25,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2018-09-20,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-09-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,3,0.0
+2019-02-16,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-24,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-01-23,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-05-23,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2019-04-15,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-11-02,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-11-15,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-03-07,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2019-03-15,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-03-05,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2019-03-14,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-01-23,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2019-02-06,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-22,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-10-25,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2018-11-09,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2019-01-09,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,2,0.0
+2018-10-03,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-01-25,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-17,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-15,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-03-24,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-03-28,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-02-18,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-20,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2019-05-21,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,3,0.0
+2018-10-22,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-10,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-24,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-01-23,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2019-01-08,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-01-04,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-23,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-01-21,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-21,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-01-20,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-11,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2018-11-24,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-02-28,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-10-30,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-03-11,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-09-27,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-05,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-10,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-24,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-11-27,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-10-13,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-10-14,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-02-28,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-11-24,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-26,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-25,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-01-26,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-18,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2018-10-07,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-01-23,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-03-30,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-16,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-02-13,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-10-15,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-15,150175881,349886458,USD,Android,Tablet,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-05,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-16,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,4,0.0
+2019-02-14,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-11-20,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-10-13,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-01-11,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-20,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2018-11-18,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-11-12,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2018-09-25,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,3,0.0
+2018-12-04,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2019-04-03,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-13,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-10-18,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,4,0.0
+2018-10-10,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2019-01-07,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2018-11-11,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-17,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2019-03-08,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-03-25,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2018-11-29,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-09,150175881,349886458,USD,Android,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-11-26,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2018-12-18,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-03-09,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-11-13,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2018-10-02,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-01,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-19,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-18,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,4,0.0
+2018-12-10,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2018-11-07,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-17,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,2,0.0
+2018-12-12,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,5,0.0
+2018-12-13,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-01-25,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-02-01,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-08,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-02-12,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-12-04,150175881,349886458,USD,iOS,Tablet,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-05-25,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-10-17,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2018-10-14,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-11-20,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2018-12-17,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-09-24,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-14,150175881,349886458,USD,iOS,Tablet,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-22,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-10-08,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-05-13,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-02-19,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-03-19,150175881,349886462,USD,BlackBerry,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-03-05,150175881,349886458,USD,Android,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-10-30,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2018-09-26,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,4,0.0
+2019-02-26,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-18,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-08,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2019-04-26,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-26,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-11-28,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2018-12-27,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-09,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-19,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-12,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-03,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-03-26,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2019-05-16,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-02-07,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-01-28,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-03,150175881,349886458,USD,iOS,Tablet,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-21,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-23,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,3,0.0
+2019-03-26,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-03-11,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-03-03,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-01,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2018-09-27,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2018-09-24,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-11-26,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-03-25,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-09,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-08,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-10-06,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-02-08,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-01-26,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-11-04,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-10-26,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,8,0.0
+2018-11-06,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-11-06,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-03,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-03-27,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-03,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-09,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-02-06,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-04-07,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-10-25,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-11-09,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-07,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-09-20,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-10-03,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,2,0.0
+2019-02-07,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2018-10-05,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-02,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,3,0.0
+2019-02-15,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-23,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-04-29,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-03-21,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,0,1,0.0
+2019-01-10,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,8,0.67
+2019-02-06,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,5,1.0
+2018-12-04,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,5,0.67
+2018-10-10,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,2,8,0.34
+2018-12-10,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,4,0.33
+2019-05-22,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,4,1.0
+2019-03-26,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,4,1.0
+2019-01-22,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,4,0.05
+2019-04-16,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,4,1.0
+2018-10-11,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,4,0.39
+2018-12-19,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,4,0.05
+2019-02-05,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,4,0.56
+2018-09-21,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,2,5,1.43
+2019-03-29,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,2,5,2.0
+2018-12-11,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,2,5,0.52
+2019-01-10,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,2,0.26
+2018-12-04,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,2,0.05
+2018-12-21,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,2,0.41
+2019-04-16,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,2,4,2.0
+2018-11-08,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,2,1.0
+2019-03-06,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,2,4,1.33
+2019-03-28,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,2,1.0
+2019-02-05,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,2,0.05
+2019-04-29,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,2,1.0
+2019-02-17,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,2,1.0
+2018-11-21,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,2,0.33
+2019-03-16,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,2,1.0
+2019-05-16,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,2,4,2.53
+2018-09-25,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,2,0.05
+2019-05-17,150175881,349886458,USD,Android,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,2,0.16
+2019-03-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,4,8,4.58
+2019-04-07,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,2,0.09
+2019-05-17,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,2,1.0
+2019-03-11,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,2,4,2.0
+2018-11-30,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,3,6,6.03
+2019-05-13,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,2,0.18
+2019-03-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,3,6,2.33
+2018-11-29,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,2,1.0
+2019-05-25,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,2,0.05
+2018-11-12,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,2,0.05
+2018-12-11,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,2,0.05
+2019-03-01,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,2,0.56
+2019-03-05,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,2,1.0
+2018-10-10,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,2,1.0
+2019-05-03,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,2,0.33
+2019-05-02,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,2,1.11
+2019-01-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,2,1.0
+2019-05-17,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,2,1.0
+2019-01-24,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,2,4,1.1
+2018-10-11,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,2,0.85
+2018-10-30,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,2,4,1.22
+2019-01-09,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,2,0.05
+2019-03-27,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,2,0.67
+2018-09-17,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,2,0.05
+2019-05-21,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,2,1.0
+2019-04-26,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,2,1.0
+2019-04-25,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,2,1.0
+2019-04-09,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,2,1.14
+2018-12-04,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,2,0.05
+2019-03-19,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,2,0.41
+2019-05-15,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,2,0.33
+2018-10-15,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,2,1.0
+2019-02-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,2,1.0
+2018-11-20,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,2,0.05
+2019-05-15,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,2,0.67
+2019-05-06,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,2,1.0
+2019-01-08,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,2,4,0.92
+2018-12-10,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,2,4,0.28
+2019-05-15,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,3,6,3.0
+2018-10-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,2,1.0
+2019-04-11,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,2,4,1.67
+2018-11-09,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,2,4,1.05
+2018-12-16,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,2,0.28
+2019-03-08,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,3,5,2.05
+2019-03-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,3,5,0.99
+2018-09-26,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,3,5,2.94
+2019-03-25,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,4,5,4.29
+2019-05-23,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,4,5,3.58
+2018-10-31,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,1,0.05
+2019-03-30,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,0.67
+2019-05-23,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,0.27
+2018-11-20,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,0.05
+2019-02-08,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,1,0.05
+2019-05-24,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,1,0.01
+2018-10-31,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,2,2,1.12
+2019-04-19,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,1.0
+2019-05-10,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,1.0
+2019-03-29,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,1,0.02
+2019-02-05,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,0.18
+2019-03-20,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,0.67
+2019-03-19,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,0.31
+2018-10-06,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,1.0
+2018-10-09,150175881,349886458,USD,iOS,Tablet,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,1,0.05
+2019-03-25,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,0.16
+2018-11-07,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,0.05
+2019-04-03,150175881,349886458,USD,iOS,Tablet,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,0.24
+2019-04-12,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,1,1.0
+2019-05-19,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,1.0
+2019-04-16,150175881,349886462,USD,Android,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,0.15
+2019-03-07,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,0.57
+2019-03-07,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,0.18
+2018-11-12,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,1,0.05
+2018-11-05,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,3,3,2.67
+2019-02-04,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,2,2,0.7
+2018-10-02,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,0.29
+2019-02-02,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,1,0.33
+2019-04-19,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,1,1.0
+2018-11-08,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,1.0
+2018-11-02,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,0.34
+2018-11-20,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,1.03
+2019-05-07,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,1.0
+2019-01-22,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,1.0
+2019-03-04,150175881,349886458,USD,Android,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,0.28
+2019-05-24,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,0.05
+2019-03-27,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,2,2,2.0
+2018-11-23,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,0.05
+2018-10-30,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Other,Current,1,1,0.05
+2019-05-19,150175881,349886458,USD,Android,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,0.24
+2019-02-04,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,1,0.05
+2018-11-17,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,0.24
+2019-01-05,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,1,0.33
+2019-03-31,150175881,349886458,USD,Android,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,0.2
+2019-05-14,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,2,2,2.0
+2019-04-15,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,1.0
+2019-01-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,2,2,0.1
+2019-04-11,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,1.0
+2019-02-18,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,0.09
+2018-10-25,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,3,3,1.45
+2018-11-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,0.11
+2019-05-14,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,4.08
+2018-11-08,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,0.18
+2018-12-16,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,1,0.05
+2018-11-15,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,0.6
+2019-02-09,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,1,0.05
+2019-05-07,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,0.12
+2018-10-11,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,0.27
+2018-10-09,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,3,3,1.62
+2018-12-10,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,0.23
+2019-02-09,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,1,0.18
+2019-04-11,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,0.05
+2019-04-18,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,1,1.0
+2018-10-08,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,1,0.05
+2019-02-11,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,0.05
+2019-03-17,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,1.0
+2018-11-19,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,3,3,0.36
+2018-09-23,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,0.04
+2019-02-05,150175881,349886458,USD,Android,Smartphone,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,0.95
+2019-05-27,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,1,1.0
+2019-03-19,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,1,1.0
+2018-11-16,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,0.27
+2018-11-27,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,2,2,0.25
+2018-11-11,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,1.0
+2019-04-09,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,1.0
+2019-05-15,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,1.0
+2018-10-03,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,0.22
+2019-05-02,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,0.12
+2019-03-22,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,0.09
+2018-12-03,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,1,0.05
+2019-03-17,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,1,1.0
+2018-10-24,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,1,0.05
+2019-05-05,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,1,1.0
+2019-02-28,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,2,2,1.37
+2018-10-24,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,3,3,3.0
+2018-11-12,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,2,2,2.0
+2018-10-16,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,0.26
+2018-12-17,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,1.36
+2019-04-23,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,0.05
+2019-05-21,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,1.0
+2018-10-23,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,0.05
+2019-01-22,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,1.0
+2018-10-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,1.09
+2019-05-28,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,1.0
+2019-05-05,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,1.0
+2019-04-25,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,0.11
+2019-05-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,1.0
+2018-09-19,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,1,0.05
+2018-09-19,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,2,2,0.56
+2018-10-15,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,0.05
+2018-12-18,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,2,2,0.66
+2019-02-27,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,0.3
+2019-04-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,1,1.0
+2019-05-18,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,2,1,0.66
+2019-05-08,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,5,8,5.0
+2018-11-28,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,3,4,1.57
+2019-03-12,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,3,4,1.68
+2019-05-14,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,3,4,6.57
+2019-02-26,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,3,4,1.1
+2018-11-01,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,3,4,1.24
+2018-10-05,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,3,4,2.47
+2019-04-10,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,3,1.0
+2019-02-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,3,0.32
+2019-01-02,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,3,0.05
+2019-04-30,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,2,6,2.0
+2018-11-06,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,3,0.33
+2019-02-14,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,2,6,1.0
+2019-01-10,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,3,0.01
+2019-05-12,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,3,1.0
+2019-04-03,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,3,1.0
+2018-10-09,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,3,0.11
+2019-02-21,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,3,1.0
+2018-12-14,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,3,0.11
+2019-05-20,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,3,1.0
+2019-01-21,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,3,4.18
+2018-10-12,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,3,0.14
+2019-03-28,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,3,1.25
+2019-02-20,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,3,0.08
+2019-01-26,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,3,0.05
+2019-05-09,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,3,0.33
+2018-12-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,3,0.05
+2018-12-07,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,3,0.33
+2019-05-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,3,1.0
+2018-10-09,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,2,6,1.19
+2019-01-07,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,3,0.33
+2019-02-21,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,3,1.0
+2019-02-19,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,3,0.67
+2018-11-27,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,2,6,0.56
+2018-11-15,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,3,0.29
+2018-10-16,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,3,0.39
+2019-04-27,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,3,1.0
+2018-11-30,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,3,0.33
+2018-12-05,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,3,0.05
+2019-03-07,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,3,0.33
+2018-10-12,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,3,0.05
+2019-02-07,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,2,7,1.21
+2019-05-02,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,2,7,1.67
+2019-04-08,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,2,3,0.23
+2019-05-09,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,2,3,1.43
+2019-04-01,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,2,3,2.0
+2019-01-23,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,2,3,0.71
+2019-03-26,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,2,3,1.21
+2019-03-18,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,2,3,1.33
+2019-03-05,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,2,3,1.59
+2019-04-17,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,2,3,2.0
+2019-02-20,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,2,3,1.39
+2019-04-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,2,3,2.63
+2019-03-27,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,2,3,2.0
+2018-10-18,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,9,2.32
+2019-02-26,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Exact,Exact,Syndicated search partners - Top,Current,1,6,0.05
+2018-12-05,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Exact,Exact,Bing and Yahoo! search - Top,Current,1,6,0.17
+2019-01-23,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-03-26,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-20,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-24,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-02,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-01,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2018-12-09,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-05-16,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-08,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-22,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-12,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-10-13,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-11-11,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-10,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-10-25,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2018-09-23,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-12,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-03-27,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-04-15,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-12,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-10-10,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-24,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-29,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-18,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-01,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-19,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-10-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-02-12,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-05,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-26,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-24,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-10-18,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-10-30,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-13,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-18,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-03-29,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-04-03,150175881,349886458,USD,iOS,Tablet,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-24,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-01,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-31,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-04-23,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2019-03-22,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-10,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-09,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-08,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2018-10-08,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-13,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-04-05,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-17,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-25,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-08,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2018-10-15,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-01-10,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-20,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-29,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-03,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-08,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-10-21,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-10-20,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2018-12-18,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-20,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-04-28,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-17,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-02-23,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-13,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-12,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-06,150175881,349886462,USD,Unknown,Computer,AOL search,Search,Phrase,Phrase,AOL search - Top,Current,0,0,0.0
+2018-11-02,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2018-09-22,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-28,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2019-05-18,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-25,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-23,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-11-29,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-17,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-02-07,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-14,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-02-27,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-28,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-04-05,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-09-24,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-21,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-11-26,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-17,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-19,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-18,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-27,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2018-12-13,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-04-10,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-01,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-30,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-14,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2018-12-13,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-09,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2018-11-25,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2018-12-07,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-08,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2018-12-08,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-10-24,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-04,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-01-06,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-01-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-03-20,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-26,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-10,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-29,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2018-10-28,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-11-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-10-26,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2018-12-14,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-19,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-03,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-04-29,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-05,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-26,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-09,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2018-09-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-12,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2018-09-17,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-06,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2019-04-24,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-15,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-24,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-12,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2018-10-09,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2018-12-11,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-10,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-11-03,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-01-10,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-09,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-23,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-09,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-14,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2018-12-06,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2018-12-10,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-03-29,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-12,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-22,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2019-04-21,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-06,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-01,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-05,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-04-03,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-09-18,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-14,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-05,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-03-20,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-14,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-14,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2018-12-07,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-11-03,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-16,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-11-08,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-04,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-03-21,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-27,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-09,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-14,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-13,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-27,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-11,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-09,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-14,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-15,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-11-03,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-02-27,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2018-12-18,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-19,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-03-24,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-16,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2018-09-23,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-08,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-27,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-12,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-10-27,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-09-20,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-13,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-11,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-23,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-10-12,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-01-05,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-04,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-16,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-14,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-11-01,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2018-09-22,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-05-27,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-10-22,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-04-10,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-10-26,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-17,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-07,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-04-04,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-05-12,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-25,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-10-13,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2018-10-21,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2018-12-12,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-19,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-15,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-06,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-12,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-04-01,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-02-28,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-09-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-03,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-01-23,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-08,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-14,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-02-20,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-02-13,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-10-14,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-20,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-09,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-01,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-22,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-11,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-09,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-10-03,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-28,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2018-10-20,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-13,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-05-13,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-20,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-03,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2018-12-07,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-11,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2018-12-16,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-21,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-12,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-07,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2018-12-19,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-05-21,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2019-05-27,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-13,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-19,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2019-04-02,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-24,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-28,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-03,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-21,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-09,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-04-29,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-10-18,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-04-09,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-02,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-16,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2018-10-12,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-01,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-10-23,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-13,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2018-12-06,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-08,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-10-09,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2018-10-16,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-01-07,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-07,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-11,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-25,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-02,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-07,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-10-10,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-11-27,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-04-19,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-08,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-02-13,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-11-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2018-12-11,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-03-27,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-17,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-08,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-03-01,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-09-24,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-04,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2018-12-25,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-01-23,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2018-12-07,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-04-09,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-01-06,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-25,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-14,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2018-10-29,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-17,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-23,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-28,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-27,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2019-02-14,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-06,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-04-29,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-11-04,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-17,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-03-10,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-09,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-09,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-08,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-04,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-04,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-21,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-04-12,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-10,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-09,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-01-23,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-05-23,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-15,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-27,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-08,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-03-10,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-10-30,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-04-09,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-10-15,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-04,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-07,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-06,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-01-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-02,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2019-04-30,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-28,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-11-25,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,0,0.0
+2018-12-10,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-02,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-01-08,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-05,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-05-16,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-15,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-03-05,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-14,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-02,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-03-18,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-05-07,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-02,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-08,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-10-17,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-06,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-03-05,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-10,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-04-08,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-08,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-04-03,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2018-09-24,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-04-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,0,0.0
+2019-05-20,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-12-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2019-02-08,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,0,0.0
+2018-11-06,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-11-16,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-10-24,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-02-19,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,3,0.0
+2018-10-09,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,2,0.0
+2018-11-13,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,4,0.0
+2018-11-13,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-03,150175881,349886458,USD,iOS,Tablet,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-12,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-01-27,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-01-22,150175881,349886458,USD,Android,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-10,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-03-18,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2018-12-15,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-19,150175881,349886458,USD,Android,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-03-27,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,3,0.0
+2018-12-05,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,2,0.0
+2018-10-22,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,4,0.0
+2018-12-12,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2018-11-08,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,1,0.0
+2018-12-06,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-02-28,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,5,0.0
+2018-09-21,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-05,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-04,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-08,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,3,0.0
+2019-04-29,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-02-14,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-12-07,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-04,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-01-07,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-01-09,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-11-09,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-15,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-11,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,4,0.0
+2019-04-09,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,4,0.0
+2018-12-05,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,14,0.0
+2018-11-13,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-11-19,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2018-12-18,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-10-26,150175881,349886458,USD,Windows,Computer,AOL search,Search,Phrase,Phrase,AOL search - Top,Current,0,3,0.0
+2018-12-21,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-16,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2018-12-06,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,2,0.0
+2019-03-05,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-02-27,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-20,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,3,0.0
+2018-11-07,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-09-21,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-02-11,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,3,0.0
+2018-12-27,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-09,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-02-21,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-10-10,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-08,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-04-07,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-01-27,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-01-04,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,3,0.0
+2019-02-13,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-17,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,7,0.0
+2019-05-17,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-02-22,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-02-20,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-03-28,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-12-06,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,6,0.0
+2018-10-09,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,3,0.0
+2018-10-15,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-03-06,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,6,0.0
+2018-12-03,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-01-08,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,3,0.0
+2018-10-02,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-01-03,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-25,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,3,0.0
+2019-04-26,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-10,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2018-11-20,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-12-05,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-02-23,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-02-07,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-02-21,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-02-06,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-10,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,6,0.0
+2018-10-23,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-09-18,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,3,0.0
+2018-10-07,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-20,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-27,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-03,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-01-25,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-31,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-02-14,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-01-07,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-02-27,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,3,0.0
+2019-03-14,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-10,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,5,0.0
+2018-09-26,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-07,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-21,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-02-01,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-10-10,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-03-13,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-12-20,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-11-02,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-03-12,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,3,0.0
+2019-03-12,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-12-04,150175881,349886458,USD,iOS,Tablet,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,3,0.0
+2019-03-27,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,9,0.0
+2018-12-04,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,3,0.0
+2019-04-24,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-02-22,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-06,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-02-11,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-12-17,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,5,0.0
+2018-11-09,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-10-24,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-11-20,150175881,349886458,USD,iOS,Tablet,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-10-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-10-04,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-04-09,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,5,0.0
+2019-03-04,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,5,0.0
+2019-02-26,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2018-09-26,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2018-11-26,150175881,349886458,USD,iOS,Tablet,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-18,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,4,0.0
+2019-04-23,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,5,0.0
+2019-04-22,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-15,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-31,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-12-05,150175881,349886462,USD,Unknown,Computer,AOL search,Search,Phrase,Phrase,AOL search - Top,Current,0,3,0.0
+2018-09-19,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,4,0.0
+2019-03-28,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-03,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-18,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,3,0.0
+2019-04-02,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-14,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-03,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-24,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,3,0.0
+2019-05-20,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,6,0.0
+2019-01-22,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,2,0.0
+2018-12-20,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,4,0.0
+2019-04-02,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,5,0.0
+2018-11-30,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-02-04,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-10-05,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-26,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-02-09,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-24,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-10-30,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,3,0.0
+2018-11-06,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,3,0.0
+2019-02-26,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,6,0.0
+2018-12-21,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-05-13,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-28,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-02-11,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-02-01,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-03-26,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2018-10-17,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,1,0.0
+2018-11-14,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,5,0.0
+2019-03-05,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-03,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,5,0.0
+2019-03-15,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-02-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-01-24,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-29,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-01-19,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-19,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-02,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-24,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-21,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-20,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,3,0.0
+2019-05-26,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-03-22,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-30,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-16,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,2,0.0
+2018-10-10,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,3,0.0
+2018-10-11,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-10-23,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-11-28,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,3,0.0
+2019-02-11,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-01-03,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,1,0.0
+2018-10-16,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-10-23,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-06,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-11-18,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-02-18,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,4,0.0
+2019-04-18,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,4,0.0
+2019-05-25,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-11-04,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-17,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-12-02,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-11,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,2,0.0
+2018-12-27,150175881,349886458,USD,iOS,Tablet,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-24,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-02-15,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-04-15,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-02-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-04,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,7,0.0
+2018-11-15,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-03-15,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-01-09,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-02-04,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-11-27,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,3,0.0
+2019-04-18,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,3,0.0
+2019-03-18,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-05-24,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-01-25,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-15,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-10-16,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2018-10-17,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,2,0.0
+2018-12-20,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-01-27,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-25,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,7,0.0
+2019-05-01,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-02-05,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,4,0.0
+2019-04-15,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,2,0.0
+2018-10-11,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-02-15,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-03-11,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-13,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,3,0.0
+2019-04-05,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,3,0.0
+2018-12-06,150175881,349886458,USD,Windows,Computer,AOL search,Search,Phrase,Phrase,AOL search - Top,Current,0,1,0.0
+2019-04-26,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,3,0.0
+2018-11-26,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-04-17,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,5,0.0
+2019-02-01,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-07,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-24,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-03-14,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,8,0.0
+2018-11-03,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-02-10,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-02-01,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-07,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-12-07,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,2,0.0
+2018-10-10,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,3,0.0
+2019-03-05,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,3,0.0
+2019-03-03,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-05,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,8,0.0
+2018-09-20,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-01-20,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-02-24,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-04-30,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,3,0.0
+2019-02-21,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-08,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,1,0.0
+2018-12-05,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,85,0.0
+2019-05-06,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,8,0.0
+2019-03-01,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-01-06,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-20,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-03-29,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,4,0.0
+2019-02-04,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-01-24,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-23,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-14,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,5,0.0
+2019-04-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,2,0.0
+2018-10-11,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-03-12,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-03,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-10,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-30,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-12,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,4,0.0
+2019-02-21,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-10-03,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,4,0.0
+2018-11-28,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-01-03,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-12-19,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,3,0.0
+2019-03-31,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-10-20,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,1,0.0
+2018-09-19,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,4,0.0
+2018-09-18,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-11,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,4,0.0
+2018-11-24,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-12-17,150175881,349886458,USD,iOS,Tablet,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-05,150175881,349886462,USD,Windows,Computer,AOL search,Search,Phrase,Phrase,AOL search - Top,Current,0,1,0.0
+2018-11-07,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-21,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-01-25,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-02,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,4,0.0
+2019-05-17,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-01-22,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-02-13,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-04-28,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-07,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-03-08,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-03-07,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-03-03,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2018-10-25,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,4,0.0
+2019-02-08,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-15,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-11-20,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-04,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-10,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2018-11-09,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,1,0.0
+2018-10-23,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-02-20,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-01-04,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-19,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-04-11,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,3,0.0
+2019-05-20,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-12-04,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-03-28,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-02-10,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-01-23,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,8,0.0
+2018-11-21,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-11,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-01,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,4,0.0
+2018-12-12,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,2,0.0
+2018-12-03,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,2,0.0
+2018-09-20,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-13,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-21,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-20,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-18,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-02-06,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-02-14,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,5,0.0
+2018-12-08,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,1,0.0
+2018-10-10,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2018-10-16,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,2,0.0
+2018-10-28,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,3,0.0
+2018-12-05,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,24,0.0
+2019-04-07,150175881,349886458,USD,iOS,Tablet,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-03-25,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,3,0.0
+2019-01-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,3,0.0
+2019-04-30,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-05-13,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,3,0.0
+2019-02-06,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,3,0.0
+2019-03-18,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-01-07,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-10-19,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,4,0.0
+2019-01-03,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,5,0.0
+2019-04-23,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-16,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-21,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-03-21,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-10-11,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-07,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,3,0.0
+2019-05-10,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,3,0.0
+2019-01-26,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-05,150175881,349886458,USD,Windows,Computer,AOL search,Search,Phrase,Phrase,AOL search - Top,Current,0,1,0.0
+2018-10-17,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2018-09-17,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-21,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-04-05,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-19,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-26,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-02-24,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-03,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-04-08,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-01-22,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,4,0.0
+2019-01-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-06,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-17,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-03-30,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-11-30,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,2,0.0
+2018-12-05,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,25,0.0
+2019-02-19,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,5,0.0
+2019-04-03,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-17,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,5,0.0
+2019-04-24,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,3,0.0
+2019-04-25,150175881,349886458,USD,iOS,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,3,0.0
+2018-10-27,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-12-21,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,3,0.0
+2019-04-25,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-17,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-01-23,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-15,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,3,0.0
+2018-10-08,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,3,0.0
+2019-04-26,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-11-09,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-11-02,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-12-17,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-02-05,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-10-05,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-23,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2018-12-15,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-11,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,3,0.0
+2018-12-10,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-02-28,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,5,0.0
+2018-12-14,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-01-26,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-01,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,4,0.0
+2018-12-04,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-02-22,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-11,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-10-24,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-13,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,4,0.0
+2019-03-08,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-02-25,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,4,0.0
+2019-02-14,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-26,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-01,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2018-12-23,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,1,0.0
+2018-12-24,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-12-14,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,2,0.0
+2018-10-17,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,3,0.0
+2018-11-12,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-03-27,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-16,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-03-19,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-16,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-22,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-03-22,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-03,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,5,0.0
+2019-03-06,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-03-13,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,1,0.0
+2018-11-01,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-12-17,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-04-05,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-05-27,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-12-05,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-02-18,150175881,349886458,USD,Android,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-05-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,2,0.0
+2018-12-05,150175881,349886458,USD,Unknown,Computer,AOL search,Search,Phrase,Phrase,AOL search - Top,Current,0,5,0.0
+2019-05-10,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-12-11,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-10-02,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,2,0.0
+2018-12-07,150175881,349886458,USD,Windows,Computer,AOL search,Search,Phrase,Phrase,AOL search - Top,Current,0,2,0.0
+2019-04-04,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,3,0.0
+2019-05-17,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-01,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-08,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-04-08,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,2,0.0
+2018-10-02,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-09-25,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,2,0.0
+2018-10-07,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-20,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-08,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-05-21,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,5,0.0
+2019-04-16,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,3,0.0
+2018-12-18,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-11-22,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-03-11,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-02-22,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-12-22,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,2,0.0
+2019-04-09,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-04-25,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2018-12-14,150175881,349886458,USD,iOS,Tablet,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2018-10-15,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2018-10-10,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2019-03-19,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,1,0.0
+2018-11-05,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2018-12-06,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,1,0.0
+2019-02-11,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Other,Current,0,2,0.0
+2018-11-26,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-05-02,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,4,0.0
+2019-04-29,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,4,0.0
+2019-02-12,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,4,0.0
+2018-10-18,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,3,0.0
+2019-03-12,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,0,3,0.0
+2019-03-14,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-02-25,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,3,0.0
+2019-02-25,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-03-22,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,3,0.0
+2019-02-13,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,2,0.0
+2019-04-29,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,0,1,0.0
+2019-02-06,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,1,5,0.18
+2019-04-15,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,5,0.09
+2018-10-26,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,5,2.49
+2019-03-26,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,1,5,0.63
+2018-10-22,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,1,4,0.27
+2019-03-13,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,4,0.92
+2019-03-17,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,1,4,0.33
+2019-04-26,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,4,1.0
+2019-01-08,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,1,4,1.06
+2019-05-02,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,2,5,2.73
+2019-03-20,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,2,5,2.21
+2018-11-01,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,2,0.05
+2019-04-02,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,1,2,1.65
+2019-03-23,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,2,1.64
+2019-02-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,2,4,0.87
+2019-05-24,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,2,0.81
+2019-04-18,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,2,2.34
+2018-09-26,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,2,0.95
+2019-05-08,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,1,2,0.55
+2019-03-29,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,2,0.48
+2019-02-06,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,2,2.25
+2019-04-27,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,2,2.02
+2019-04-05,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,2,1.07
+2019-05-06,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,2,0.83
+2019-05-17,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,2,4,2.6
+2019-04-09,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,2,0.53
+2019-03-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,2,1.15
+2019-03-19,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,1,2,0.54
+2019-04-03,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,2,4,2.25
+2019-04-01,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,2,2.61
+2018-12-12,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,1,2,0.05
+2019-05-28,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,2,1.0
+2019-02-15,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,2,2.44
+2019-05-01,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,2,1.0
+2019-02-05,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,2,4,2.88
+2019-05-01,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,1,2,0.3
+2018-09-21,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,4,8,7.51
+2018-12-19,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,2,1.36
+2018-11-27,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,2,1.19
+2019-05-02,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,2,1.0
+2019-04-15,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,2,2.08
+2019-05-08,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,2,1.0
+2018-11-29,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,2,4,3.03
+2019-05-12,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,2,1.0
+2019-05-06,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,1,1,0.3
+2018-12-04,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,1,1.78
+2018-12-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,1,2.33
+2019-02-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,1,2.28
+2019-01-22,150175881,349886458,USD,Android,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,1,1,0.29
+2019-03-07,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,1,1.0
+2018-12-26,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,1,2.82
+2019-02-17,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,1,0.05
+2019-05-09,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,1,0.54
+2018-10-12,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,2,2,0.96
+2019-01-10,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,1,1,0.04
+2018-11-26,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,1,1.12
+2019-03-29,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,1,1,1.0
+2018-11-14,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,1,2.28
+2018-09-20,150175881,349886458,USD,Android,Smartphone,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,1,0.85
+2019-05-15,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,1,1.09
+2019-01-28,150175881,349886462,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,1,5.39
+2019-05-02,150175881,349886458,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,1,0.9
+2019-02-07,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,1,1.61
+2019-03-19,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,1,1,1.0
+2019-03-14,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,1,0.77
+2018-11-07,150175881,349886462,USD,Unknown,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,1,1.06
+2018-10-19,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,1,2.79
+2019-05-07,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,1,0.69
+2019-05-22,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,3,1.49
+2019-01-24,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,1,3,0.05
+2019-02-12,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,1,3,0.06
+2019-04-05,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,2,6,1.97
+2018-10-07,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,3,3.07
+2019-02-27,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,3,1.97
+2019-05-20,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,1,3,0.05
+2018-10-08,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,3,1.0
+2019-02-15,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,1,3,2.17
+2019-03-11,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,3,2.83
+2018-12-04,150175881,349886458,USD,iOS,Smartphone,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,1,3,0.04
+2019-03-28,150175881,349886458,USD,Windows,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,1,3,1.0
+2019-04-04,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,3,1.0
+2018-11-28,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,3,1.22
+2018-12-05,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,61,1.32
+2019-02-26,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,2,3,0.72
+2019-05-23,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,2,3,2.36
+2019-05-14,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,3,7,2.19
+2018-11-22,150175881,349886458,USD,Unknown,Computer,Syndicated search partners,Search,Phrase,Phrase,Syndicated search partners - Top,Current,1,9,0.28
+2018-12-06,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,9,1.27
+2019-03-01,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,13,1.48
+2018-10-09,150175881,349886458,USD,Windows,Computer,Bing and Yahoo! search,Search,Phrase,Phrase,Bing and Yahoo! search - Top,Current,1,6,1.16

--- a/packages.yml
+++ b/packages.yml
@@ -38,7 +38,7 @@ packages:
   # - package: fivetran/microsoft_ads
   #   version: [">=0.6.0", "<0.7.0"]
     - git: https://github.com/fivetran/dbt_microsoft_ads.git
-      revision: bugfix/budget-association-issue-21
+      revision: MagicBot/dbt-utils-cross-db-migration
       warn-unpinned: false
 
   # - package: fivetran/tiktok_ads

--- a/packages.yml
+++ b/packages.yml
@@ -38,7 +38,7 @@ packages:
   # - package: fivetran/microsoft_ads
   #   version: [">=0.6.0", "<0.7.0"]
     - git: https://github.com/fivetran/dbt_microsoft_ads.git
-      revision: MagicBot/dbt-utils-cross-db-migration
+      revision: bugfix/budget-association-issue-21
       warn-unpinned: false
 
   # - package: fivetran/tiktok_ads


### PR DESCRIPTION
**Are you a current Fivetran customer?** 
<!--- Please tell us your name, title and company -->
Fivetran employee

**What change(s) does this PR introduce?** 
<!--- Describe what changes your PR introduces to the package and how to leverage this new feature. -->
- Added `budget_association_status` into the `stg_microsoft_ads__campaign_daily_report` table in order to account for campaign budgets that end midday. Including `budget_association_status` as another grain to test by, will reduce tests failing due to non-uniqueness of rows. This change will therefore yield an update this package's `integration_tests/seeds/microsoft_ads_campaign_performance_daily_report_data`. 

**Did you update the CHANGELOG?** 
<!--- Please update the new package version’s CHANGELOG entry detailing the changes included in this PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Yes

**Does this PR introduce a breaking change?**
<!--- Does this PR introduce changes that will cause current package users' jobs to fail or require a `--full-refresh`? -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Yes (please provide breaking change details below.)
- [x] No  (please provide an explanation as to how the change is non-breaking below.)

**Did you update the dbt_project.yml files with the version upgrade (please leverage standard semantic versioning)? (In both your main project and integration_tests)** 
<!--- The dbt_project.yml and the integration_tests/dbt_project.yml files contain the version number. Be sure to upgrade it accordingly -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Yes
N/A rolling out with dbt utils 1.0 and buildkite migrations

**Is this PR in response to a previously created Bug or Feature Request**
<!--- If an Issue was created it is helpful to track the progress by linking it in the PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Yes, Issue/Feature [[link bug/feature number here](https://github.com/fivetran/dbt_microsoft_ads_source/issues/21)]
- [ ] No 

**How did you test the PR changes?** 
<!--- Proof of testing is required in order for the PR to be approved. -->
<!--- To check a box, remove the space and insert an x in the box (eg. [x] CircleCi). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] CircleCi <!--- CircleCi testing is only applicable to Fivetran employees. --> 
- [x] Local (please provide additional testing details below)

**Select which warehouse(s) were used to test the PR**
<!--- To check a warehouse remove the space and insert an x in the box (eg. [x] Bigquery). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] BigQuery
- [x] Redshift
- [x] Snowflake
- [x] Postgres
- [x] Databricks
- [x] Other (provide details below)

**Provide an emoji that best describes your current mood**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
:dancer:

**Feedback**

We are so excited you decided to contribute to the Fivetran community dbt package! We continue to work to improve the packages and would greatly appreciate your [feedback](https://www.surveymonkey.com/r/DQ7K7WW) on our existing dbt packages or what you'd like to see next.
