### PR TITLE
Bugfix/twitter microsoft keywords search

### DIFF
--- a/models/ad_reporting_models.yml
+++ b/models/ad_reporting_models.yml
@@ -167,10 +167,10 @@ models:
         description: '{{ doc("ad_group_name") }}'
       - name: keyword_id
         description: '{{ doc("keyword_id") }}'
-      - name: keyword_text
-        description: '{{ doc("keyword_text") }}'
         tests:
           - not_null
+      - name: keyword_text
+        description: '{{ doc("keyword_text") }}'
       - name: keyword_match_type
         description: '{{ doc("keyword_match_type") }}'
       - name: clicks

--- a/models/intermediate/int_ad_reporting__keyword_report.sql
+++ b/models/intermediate/int_ad_reporting__keyword_report.sql
@@ -80,7 +80,7 @@ twitter_ads as (
         field_mapping={
                 'ad_group_id': 'line_item_id',
                 'ad_group_name': 'line_item_name',
-                'keyword_id': 'null',
+                'keyword_id': 'keyword_id',
                 'keyword_text': 'keyword',
                 'keyword_match_type': 'null'
             },

--- a/packages.yml
+++ b/packages.yml
@@ -17,11 +17,17 @@ packages:
   - package: fivetran/linkedin
     version: [">=0.5.0", "<0.6.0"]
 
-  - package: fivetran/microsoft_ads
-    version: [">=0.5.0", "<0.6.0"]
+  # - package: fivetran/microsoft_ads
+  #   version: [">=0.5.0", "<0.6.0"]
+  - git: https://github.com/fivetran/dbt_microsoft_ads.git
+    revision: bugfix/match-type-report-adjustments
+    warn-unpinned: false
 
   - package: fivetran/tiktok_ads
     version: [">=0.2.0", "<0.3.0"]
 
-  - package: fivetran/twitter_ads
-    version: [">=0.5.0", "<0.6.0"]
+  # - package: fivetran/twitter_ads
+  #   version: [">=0.5.0", "<0.6.0"]
+  - git: https://github.com/fivetran/dbt_twitter.git
+    revision: bugfix/keyword-id-addition
+    warn-unpinned: false


### PR DESCRIPTION
**Are you a current Fivetran customer?** 
<!--- Please tell us your name, title and company -->
Fivetran created PR

**What change(s) does this PR introduce?** 
<!--- Describe what changes your PR introduces to the package and how to leverage this new feature. -->

## Feature Enhancement
- The `keyword_id` field has been added to the `ad_reporting__keyword_report` model for the Twitter Ads platform.

## Bugfixes
- The `not_null` test on the `ad_reporting__keyword_report` has been adjusted to be tested on the `keyword_id` as opposed to the `keyword_text`. This is needed as there may be times where keyword historical records may be removed and lose reference in an upstream join. As such, the text may be lost and the null test should be applied to the ID instead.

## Contributors
- [@clay-walker](https://github.com/clay-walker) for being instrumental in understanding and addressing this issue. ([#63](https://github.com/fivetran/dbt_ad_reporting/issues/63))

**Did you update the CHANGELOG?** 
<!--- Please update the new package version’s CHANGELOG entry detailing the changes included in this PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [X] Yes

**Does this PR introduce a breaking change?**
<!--- Does this PR introduce changes that will cause current package users' jobs to fail or require a `--full-refresh`? -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Yes (please provide breaking change details below.)
- [X] No  (please provide an explanation as to how the change is non-breaking below.)

**Did you update the dbt_project.yml files with the version upgrade (please leverage standard semantic versioning)? (In both your main project and integration_tests)** 
<!--- The dbt_project.yml and the integration_tests/dbt_project.yml files contain the version number. Be sure to upgrade it accordingly -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [X] Yes

**Is this PR in response to a previously created Bug or Feature Request**
<!--- If an Issue was created it is helpful to track the progress by linking it in the PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [X] Yes, ([#63](https://github.com/fivetran/dbt_ad_reporting/issues/63))
- [ ] No 

**How did you test the PR changes?** 
<!--- Proof of testing is required in order for the PR to be approved. -->
<!--- To check a box, remove the space and insert an x in the box (eg. [x] Buildkite). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [X] Buildkite <!--- Buildkite testing is only applicable to Fivetran employees. --> 
- [X] Local (please provide additional testing details below)

**Select which warehouse(s) were used to test the PR**
<!--- To check a warehouse remove the space and insert an x in the box (eg. [x] Bigquery). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [X] BigQuery
- [X] Redshift
- [X] Snowflake
- [X] Postgres
- [X] Databricks
- [ ] Other (provide details below)

**Provide an emoji that best describes your current mood**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
👨‍🚀 

**Feedback**

We are so excited you decided to contribute to the Fivetran community dbt package! We continue to work to improve the packages and would greatly appreciate your [feedback](https://www.surveymonkey.com/r/DQ7K7WW) on our existing dbt packages or what you'd like to see next.
