### PR TITLE
Update README.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 contact_links:
-  - name: Ask a question during our office hours
-    url: https://calendly.com/fivetran-solutions-team/fivetran-solutions-team-office-hours
-    about: Schedule time during the external office hours block with the Fivetran Analytics Engineering team for support
+  - name: Provide feedback or request a new package to our dbt package team
+    url: https://www.surveymonkey.com/r/DQ7K7WW
+    about: Fill out our survey form to provide valuable feedback to the Fivetran team developing and maintaining the dbt packages.
   - name: Fivetran connector question
     url: https://support.fivetran.com/hc
     about: Have a question about your connector? Check out the Fivetran support portal for more details.

--- a/README.md
+++ b/README.md
@@ -639,4 +639,4 @@ We highly encourage and welcome contributions to this package. Check out [this p
 # 🏪 Are there any resources available?
 - If you encounter any questions or want to reach out for help, please refer to the [GitHub Issue](https://github.com/fivetran/dbt_ad_reporting/issues/new/choose) section to find the right avenue of support for you.
 - If you would like to provide feedback to the dbt package team at Fivetran, or would like to request a future dbt package to be developed, then feel free to fill out our [Feedback Form](https://www.surveymonkey.com/r/DQ7K7WW).
-- Have questions or want to just say hi? Book a time during our office hours [here](https://calendly.com/fivetran-solutions-team/fivetran-solutions-team-office-hours) or send us an email at solutions@fivetran.com.
+- Have questions or want to be part of the community discourse? Create a post in the [Fivetran community](https://community.fivetran.com/t5/user-group-for-dbt/gh-p/dbt-user-group) and our team along with the community can join in on the discussion!


### PR DESCRIPTION
This PR includes changes to our docs which deprecates the Calendly office hours support. We now request users go through the Fivetran Community before determining if office hours are needed.