### PR TITLE
documentation/cross-db-clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Do NOT include the individual ad platform packages in this file. The ad reportin
 
 ### Step 3: Configure Database and Schema Variables
 By default, this package looks for your ad platform data in your target database. If this is not where your app platform data is stored, add the relevant `<connector>_database` variables to your `dbt_project.yml` file (see below).
+> Please note, cross-database querying, where the `*_database` variable differs from the database specified in your `profiles.yml`, is not supported by all dbt adapters (e.g., dbt-redshift). Refer to the documentation for your specific destination adapter for more details on its capabilities.
 
 ```yml
 vars:


### PR DESCRIPTION
As a result of the discovery within Issue #126 it has become apparent that not all dbt destination adapters support cross-db querying (where the `*_database` variable differs from the database specified in your `profiles.yml`). As such, we should add clarification to our documentation that specifying a database different from one of your `profiles.yml` may work on some adapters, but then may not work on others. This is all determined by the dbt adapter being used and it's capabilities.